### PR TITLE
Remove usage of maps

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   description: TileDB Storage Platform REST API
   title: Tiledb Storage Platform API
-  version: 0.0.8
+  version: 0.0.9
 
 produces:
 - application/json
@@ -10,6 +10,7 @@ consumes:
 - application/json
 schemes:
 - https
+- http
 
 basePath: /v1
 
@@ -890,6 +891,16 @@ definitions:
         alias: "tiledb"
       type: "Query"
 
+  NonEmptyDomainArray:
+    type: object
+    description: object represening non-empty domain with dimension name
+    properties:
+      name:
+        type: string
+        description: dimension name
+        example: "d1"
+      domain:
+        $ref: "#/definitions/DomainArray"
   NonEmptyDomain:
     type: object
     description: object representing a non-empty domain
@@ -898,10 +909,10 @@ definitions:
       - isEmpty
     properties:
       nonEmptyDomain:
-        type: object
+        type: array
         description: Non Empty Dmoain of array
-        additionalProperties:
-          $ref: "#/definitions/DomainArray"
+        items:
+          $ref: "#/definitions/NonEmptyDomainArray"
       isEmpty:
         description: Is non-empty domain really empty?
         type: boolean

--- a/tiledb-rest.capnp
+++ b/tiledb-rest.capnp
@@ -362,10 +362,18 @@ struct Query {
     # Limit dense operations to these dimensions
 }
 
+struct NonEmptyDomainArray {
+  # object represening non-empty domain with dimension name
+  name @0 :Text;
+  #dimension name
+
+  domain @1 :DomainArray;
+}
+
 struct NonEmptyDomain {
   # object representing a non-empty domain
 
-  nonEmptyDomain @0 :Map(Text, DomainArray);
+  nonEmptyDomain @0 :List(NonEmptyDomainArray);
   # Non Empty Dmoain of array
 
   isEmpty @1 :Bool;


### PR DESCRIPTION
Remove all usage of maps, they do not align between capnp and json.

- Remove usage of maps for non_empty_domain