### PR TITLE
Remove unused namespace requirement from AWSAccessCredentials

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1184,7 +1184,6 @@ definitions:
     description: Model representing aws keys or service role, service roles are currently ignored, but will be preferred option in the future
     type: object
     required:
-      - namespace
       - buckets
     properties:
       secretAccessKey:


### PR DESCRIPTION
Remove unused namespace requirement from AWSAccessCredentials