### PR TITLE
Remove global write state.

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -612,94 +612,6 @@ definitions:
             type: integer
             format: uint64
 
-  Tile:
-    description: last tile written
-    type: object
-    required:
-      - type
-      - cellSize
-      - dimNum
-      - buffer
-    properties:
-      type:
-        type: string
-        $ref: "#/definitions/Datatype"
-        example: "INT32"
-      cellSize:
-        description: Size of cells for writting
-        type: integer
-        format: uint64
-        example: "10"
-      dimNum:
-        description: number of dimensions
-        type: integer
-        format: uint64
-        example: "10"
-      buffer:
-        description: buffer of data
-        type: object
-        properties:
-          int8:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: int8
-          uint8:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: uint8
-          int16:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: int16
-          uint16:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: uint16
-          int32:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: int32
-          uint32:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: uint32
-          int64:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: int64
-          uint64:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: uint64
-          float32:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: float
-          float64:
-            type: array
-            x-omitempty: true
-            items:
-              type: integer
-              format: double
-
   FragmentMetadata:
     description: FragmentMetadata for GLOBAL_ORDER writes
     type: object
@@ -921,33 +833,9 @@ definitions:
           type: integer
           format: uint64
 
-  GlobalWriteState:
-    description: state of global writes
-    type: object
-    required:
-      - cellsWritten
-      - lastTiles
-    properties:
-      lastTiles:
-        description: last tiles written to disk
-        type: array
-        items:
-          $ref: "#/definitions/Tile"
-      cellsWritten:
-        description: Cells written so far in global write
-        type: object
-        additionalProperties:
-          type: integer
-          format: uint64
-      fragmentMetadata:
-        description: FragmentMetadata for GLOBAL_ORDER writes
-        $ref: "#/definitions/FragmentMetadata"
-
   Writer:
     type: object
     properties:
-      globalWriteState:
-        $ref: "#/definitions/GlobalWriteState"
       checkCoordDups:
         type: boolean
       dedupCoords:

--- a/tiledb-rest.capnp
+++ b/tiledb-rest.capnp
@@ -306,55 +306,16 @@ struct FragmentMetadata {
   # timestamp array was opened
 }
 
-struct GlobalWriteState {
-# state of global writes
-    cellsWritten @0 :MapInt64;
-    # Cells written so far in global write
-
-    lastTiles @1 :Map(Text, List(Tile));
-    # last tiles written to disk
-
-    fragmentMetadata @2 :FragmentMetadata;
-}
-
-struct Tile {
-# last tile written
-
-    cellSize @0 :UInt64;
-    # Size of cells for writting
-
-    dimNum @1 :UInt32;
-    # number of dimensions
-
-    type @2 :Text;
-    # datatype of tile
-
-    buffer :union {
-      int8 @3 :List(Int8);
-      uint8 @4 :List(UInt8);
-      int16 @5 :List(Int16);
-      uint16 @6 :List(UInt16);
-      int32 @7 :List(Int32);
-      uint32 @8 :List(UInt32);
-      int64 @9 :List(Int64);
-      uint64 @10 :List(UInt64);
-      float32 @11 :List(Float32);
-      float64 @12 :List(Float64);
-    }
-    # buffer of data
-}
 
 struct Writer {
   # Write struct
-  globalWriteState @0 :GlobalWriteState;
+  checkCoordDups @0 :Bool;
 
-  checkCoordDups @1 :Bool;
+  dedupCoords @1 :Bool;
 
-  dedupCoords @2 :Bool;
+  initialized @2 :Bool;
 
-  initialized @3 :Bool;
-
-  fragmentUri @4 :Text;
+  fragmentUri @3 :Text;
 }
 
 struct ReadState {


### PR DESCRIPTION
Global order queries won't be supported for now.

Companion with https://github.com/Shelnutt2/TileDB/pull/21

**Note** this PR is to `ttd/capnp-wip` not master.