### PR TITLE
Remove message/code required from error

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   description: TileDB Storage Platform REST API
   title: Tiledb Storage Platform API
-  version: 0.1.1
+  version: 0.1.2
 
 produces:
 - application/json
@@ -700,9 +700,6 @@ definitions:
 
   Error:
     type:  object
-    required:
-      - message
-      - code
     properties:
       code:
         type: integer


### PR DESCRIPTION
Making these fields required means when the model is code generated in golang they are pointers. This makes it harder to use and you can't just print the error model to log.