### PR TITLE
Adjust aws credentials default field to always be returned

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   description: TileDB Storage Platform REST API
   title: Tiledb Storage Platform API
-  version: 0.1.7
+  version: 0.1.8
 
 produces:
 - application/json
@@ -1092,6 +1092,7 @@ definitions:
       default:
         type: boolean
         description: true if this is the default credential to be used within this namespace
+        x-omitempty: false
       buckets:
         description: a whitelist of one or more buckets this key should access
         type: array


### PR DESCRIPTION
Adjust aws credentials default field to always be returned