### PR TITLE
Remove requiring fields from AWS credentials object

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1072,9 +1072,6 @@ definitions:
   AWSAccessCredentials:
     description: Model representing aws keys or service role, service roles are currently ignored, but will be preferred option in the future
     type: object
-    required:
-      - secret_access_key
-      - access_key_id
     properties:
       secret_access_key:
         type: string


### PR DESCRIPTION
Remove requiring fields from AWS credentials object.

Part of https://github.com/TileDB-Inc/TileDB-MVP-UI/issues/246