### PR TITLE
Add session route to public api

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2519,6 +2519,29 @@ paths:
           description: error response
           schema:
             $ref: "#/definitions/Error"
+
+  /session:
+    parameters:
+      - name: remember_me
+        in: query
+        description: flag to create a token with expiration of 30 days, default is false
+        type: string
+        required: false
+    get:
+      tags:
+        - user
+      description: Get session token for user
+      operationId: getSession
+      responses:
+        200:
+          description: Session token
+          schema:
+            $ref: "#/definitions/Token"
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+
   /tasks:
     parameters:
       - name: namespace


### PR DESCRIPTION
This allows user through the python cloud api to get proper sessions so we don't store username/passwords in tiledb-cloud config