### PR TITLE
We return the array task header for error

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1877,12 +1877,16 @@ paths:
           headers:
             X-TILEDB-CLOUD-TASK-ID:
               type: string
-              description: Task ID for just completed query
+              description: Task ID for just completed request
           schema:
             type: string
             format: binary
         default:
           description: error response
+          headers:
+            X-TILEDB-CLOUD-TASK-ID:
+              type: string
+              description: Task ID for just request if task was started
           schema:
             $ref: "#/definitions/Error"
 


### PR DESCRIPTION
This is true if the task starts, a header is returned