### PR TITLE
Add buffers parameter for setting attrs to fetch

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   description: TileDB Storage Platform REST API
   title: TileDB Storage Platform API
-  version: 1.2.0
+  version: 1.3.6
 
 produces:
 - application/json
@@ -1497,6 +1497,12 @@ definitions:
       exec:
         type: string
         description: Type-specific executable text
+      buffers:
+        description: List of buffers to fetch (attributes + coordinates)
+        type: array
+        x-omitempty: true
+        items:
+          type: string
 
   SQLParameters:
     description: Parameters for running sql query


### PR DESCRIPTION
This is called buffers not attributes for in TileDB 1.8 we will support split buffers for coordinates so eventually this will support that