### PR TITLE
Add Accept-Encoding header for udf submit

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1986,6 +1986,10 @@ paths:
         in: header
         description: Name of organization or user who should be charged for this request
         type: string
+      - name: Accept-Encoding
+        in: header
+        description: Encoding to use
+        type: string
 
     post:
       description: send a UDF to run against a specified array/URI registered to a group/project


### PR DESCRIPTION
This is a workaround to the TileDB-Cloud-Py autogenerated client not providing a way to set supported compression on the http request. By adding a header to the spec this becomes an option for the kwargs of the Apply function.

urllib3 happens to also check for the `Content-Encoding` response header and auto decodes the response data.

Not bumping the api version here because the header is already supported in the server, this just makes it explicit only for the python code generation.