### PR TITLE
Add enabled_features to user/organization model

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1143,6 +1143,13 @@ definitions:
         x-omitempty: true
         items:
           $ref: "#/definitions/NamespaceActions"
+      enabled_features:
+        description: List of extra/optional/beta features to enable for namespace
+        type: array
+        x-omitempty: true
+        readOnly: true
+        items:
+          type: string
 
   OrganizationUser:
     description: user in an organization
@@ -1222,6 +1229,14 @@ definitions:
         type: number
         format: int32
         x-omitempty: false
+      enabled_features:
+        description: List of extra/optional/beta features to enable for namespace
+        type: array
+        x-omitempty: true
+        readOnly: true
+        items:
+          type: string
+
 
   ArraySharing:
     description: details for sharing a given array


### PR DESCRIPTION
This will be use to signal to the UI additional features a particular user should be exposed to.

There is no enum for features because it will change over time, currently there is two possibilities `notebooks` and `monetization`.

We omit empty so as to hide this from users which are not exposed to any beta or trial features.