### PR TITLE
Add has_task_id to query params for activity log route

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2597,6 +2597,10 @@ paths:
         in: query
         type: string
         description: Array task id To filter activity to
+      - name: has_task_id
+        in: query
+        type: boolean
+        description: Excludes activity log results that does not contain an array task uuid 
     get:
       description: get array activity logs
       tags:


### PR DESCRIPTION
Adds has_task_id bool to filter the results to only activity log results containing array_tasks 