### PR TITLE
Add var-sized attribute offsets settings to query reader

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -760,6 +760,12 @@ definitions:
       readState:
         description: To handle incomplete read queries.
         $ref: '#/definitions/ReadState'
+      varOffsetsMode:
+        description: The offsets format (bytes or elements) to be used.
+        type: string
+      varOffsetsAddExtraElement:
+        description: True if an extra element will be added to the end of the offsets buffer.
+        type: boolean
 
   Query:
     type: object

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -766,6 +766,10 @@ definitions:
       varOffsetsAddExtraElement:
         description: True if an extra element will be added to the end of the offsets buffer.
         type: boolean
+      varOffsetsBitsize:
+        description: The offsets bitsize (32 or 64) to be used.
+        type: integer
+        format: uint32
 
   Query:
     type: object


### PR DESCRIPTION
This is the openAPI specification part of the capnp changes for supporting new configuration options for variable-sized offset buffers (Arrow format compatibility).

The PR for the capnp changes is:: https://github.com/TileDB-Inc/TileDB/pull/1932