### PR TITLE
Add SQL parameters for severless SQL

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1080,6 +1080,12 @@ definitions:
         items:
           type: string
           description: sql query or command to run before main sql query
+      sql_parameters:
+        description: SQL query parameters
+        type: array
+        items:
+          type: {}
+          description: parameter for sql query, any datatype supported
 
   PaginationMetadata:
     properties:
@@ -2200,6 +2206,12 @@ definitions:
         items:
           type: string
           description: sql query or command to run before main sql query
+      sql_parameters:
+        description: SQL query parameters
+        type: array
+        items:
+          type: {}
+          description: parameter for sql query, any datatype supported
 
   NotebookStatus:
     description: Status details of a notebook server


### PR DESCRIPTION
This adds support for the user to use `?` syntax in their sql queries and they can include the list of parameters to pass in in their request.