### PR TITLE
Remove task retry support

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -4121,31 +4121,6 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /task/{id}/retry:
-    parameters:
-      - name: id
-        in: path
-        description: task id to retry
-        type: string
-        required: true
-      - name: Accept-Encoding
-        in: header
-        description: Encoding to use
-        type: string
-    post:
-      tags:
-        - tasks
-      description: Retry an array task
-      responses:
-        200:
-          description: Array task
-          schema:
-            $ref: "#/definitions/ArrayTask"
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
-
   /task/{id}/result:
     parameters:
       - name: id


### PR DESCRIPTION
Task retry has not been used, and lacks features and support-ability for its intended use. This will be re-added in the near future with a new route.