### PR TITLE
Add exclude/include file_type filtering in task listing

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -4026,6 +4026,20 @@ paths:
         type: array
         items:
           type: string
+      - name: file_type
+        in: query
+        description: match file_type of task array, more than one can be included
+        required: false
+        type: array
+        items:
+          type: string
+      - name: exclude_file_type
+        in: query
+        description: exclude file_type of task arrays, more than one can be included
+        required: false
+        type: array
+        items:
+          type: string
       - name: status
         in: query
         description: Filter to only return these statuses

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -4030,6 +4030,7 @@ paths:
         in: query
         description: match file_type of task array, more than one can be included
         required: false
+        collectionFormat: multi
         type: array
         items:
           type: string
@@ -4037,6 +4038,7 @@ paths:
         in: query
         description: exclude file_type of task arrays, more than one can be included
         required: false
+        collectionFormat: multi
         type: array
         items:
           type: string


### PR DESCRIPTION
The default array format of query parameters in swagger is [comma separated (collectionFormat: csv)](https://swagger.io/docs/specification/2-0/describing-parameters/) and what we have used so far (e.g. `?file_type=notebook,user_defined_function` ).

The problem that rises, is that our generated clients expect the parameter to be an array of strings but in reality what we get is one string with comma separated values that we have to manually split, making our code prone to bugs.

```
	excludeTaskType := r.URL.Query()["exclude_type"]
	if excludeTaskType != nil {
		// We are sending exclude_file_type as a comma separated value
		excludeTaskType := strings.Split(excludeTaskType[0], ",")
	....
	}
```

This PR introduces `collectionFormat: multi`
> Multiple parameter instances rather than multiple values. This is only supported for the in: query and in: formData parameters. (e.g. foo=value&foo=another_value)

Instead of sending comma separated values we send multiple parameters. Αs a result, the received parameters will be an array of strings and will reflect to the generated types.

```
fileTaskTypes := r.URL.Query()["file_type"]
  if len(fileTaskTypes) > 0 {
        ....
  }
}
```