### PR TITLE
Add route for reading/writing array metadata

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -874,7 +874,7 @@ definitions:
         type: string
       type:
         type: string
-      value_num:
+      valueNum:
         type: integer
         format: uint32
       value:
@@ -889,7 +889,7 @@ definitions:
     type: object
     description: user's TileDB array metadata
     properties:
-      ranges:
+      entries:
         description: List of metadata entries
         type: array
         x-omitempty: true
@@ -2703,6 +2703,64 @@ paths:
       responses:
         204:
           description: deregistered array successful
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+
+  /arrays/{namespace}/{array}/array_metadata:
+    parameters:
+      - name: namespace
+        in: path
+        description: namespace array is in (an organization name or user's username)
+        type: string
+        required: true
+      - name: array
+        in: path
+        description: name/uri of array that is url-encoded
+        type: string
+        required: true
+    get:
+      description: get metadata on an array
+      tags:
+        - array
+      produces:
+        - application/json
+        - application/capnp
+      consumes:
+        - application/json
+        - application/capnp
+      operationId: getArrayMetadataCap
+      responses:
+        200:
+          description: array metadata for an array
+          schema:
+            $ref: "#/definitions/ArrayMetadata"
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+    post:
+      description: update metadata on an array
+      tags:
+        - array
+      produces:
+        - application/json
+        - application/capnp
+      consumes:
+        - application/json
+        - application/capnp
+      operationId: updateArrayMetadataCap
+      parameters:
+        - name: arrayMetadataEntries
+          in: body
+          description: List of metadata entries
+          schema:
+            $ref: "#/definitions/ArrayMetadata"
+          required: true
+      responses:
+        200:
+          description: array metadata updated successfully
         default:
           description: error response
           schema:


### PR DESCRIPTION
Swagger uses [keywords consumes & produces](https://swagger.io/docs/specification/2-0/describing-parameters#header-parameters) for user to define `Accept` & `Content-Type` headers.
