### PR TITLE
Add read_only property in ArrayInfoUpdate definition

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1764,6 +1764,11 @@ definitions:
         type: string
         x-omitempty: true
         description: License text
+      read_only:
+        description: Suggests if the array is in read_only mode
+        type: boolean
+        x-omitempty: true
+        example: true
 
   TokenRequest:
     description: A request from a user for an api token

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1715,6 +1715,7 @@ definitions:
       read_only:
         description: Suggests if the array is in read_only mode
         type: boolean
+        x-nullable: true
         example: false
 
   ArrayInfoUpdate:


### PR DESCRIPTION
This property was missing from the definition, but this is how we mark/unmark an array as read-only.