### PR TITLE
Capitalize CloudProvider enum values; add "secret" struct tags.

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -582,6 +582,7 @@ definitions:
       secret_access_key:
         description: "The access key's secret. Never returned in responses."
         type: string
+        x-go-custom-tag: 'tdbrest:"secret"'
       # service role ARN is not yet supported.
 
   AzureCredential:
@@ -595,13 +596,14 @@ definitions:
       account_key:
         description: "The secret key. Never returned in responses."
         type: string
+        x-go-custom-tag: 'tdbrest:"secret"'
 
   CloudProvider:
     description: "A service where data is stored or computations take place."
     type: "string"
     enum:
-      - "aws"  # Amazon Web Services
-      - "azure"  # Microsoft Azure
+      - "AWS"  # Amazon Web Services
+      - "AZURE"  # Microsoft Azure
 
 paths:
   /arrays/{namespace}/{array}/query/submit:


### PR DESCRIPTION
- Capitalize CloudProvider enum values to make operating with the
  existing database schema easier.
- Add a custom Go struct tag so that we automatically don't serialize
  secret fields to the user.

---

Sorry for the late change—originally, I had seen some of our enums were lowercased, but I now see that others are capitalized. Things will be Easier if all the values are capitalized.