### PR TITLE
Add pagination metadata to credentials response

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1096,12 +1096,12 @@ definitions:
   PaginationMetadata:
     properties:
       page:
-        description: pagination offset
+        description: pagination offset. Use it to skip the first ((page - 1) * per_page) items
         type: number
         format: uint64
         example: 1
       per_page:
-        description: pagination limit
+        description: pagination limit (page size)
         type: number
         format: uint64
         example: 10

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -507,12 +507,12 @@ definitions:
   PaginationMetadata:
     properties:
       page:
-        description: pagination offset
+        description: pagination offset. Use it to skip the first ((page - 1) * per_page) items
         type: number
         format: uint64
         example: 1
       per_page:
-        description: pagination limit
+        description: pagination limit (page size)
         type: number
         format: uint64
         example: 10

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -570,6 +570,19 @@ definitions:
             $ref: "#/definitions/AWSCredential"
           azure:
             $ref: "#/definitions/AzureCredential"
+  
+  AccessCredentialsData:
+    description: Object including credentials and pagination metadata
+    type: object
+    properties:
+      credentials:
+        description: List of credentials
+        type: array
+        x-omitempty: false
+        items:
+          $ref: "#/definitions/AccessCredential"
+      pagination_metadata:
+        $ref: "#/definitions/PaginationMetadata"
 
   AWSCredential:
     description: "Credential information to access Amazon Web Services"
@@ -761,9 +774,7 @@ paths:
         200:
           description: "Available credentials are returned"
           schema:
-            type: array
-            items:
-              $ref: "#/definitions/AccessCredential"
+            $ref: "#/definitions/AccessCredentialsData"
         default:
           description: error response
           schema:

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -764,6 +764,14 @@ paths:
         in: query
         description: "Show only the credentials from this provider. This should be one of the CloudProvider enum values."
         type: string
+      - name: page
+        in: query
+        description: pagination offset
+        type: integer
+      - name: per_page
+        in: query
+        description: pagination limit
+        type: integer
     get:
       tags:
         - user


### PR DESCRIPTION
This PR changes the response of the listCredentials route to return an object with credentials and pagination metadata instead of an array.
Returning an object (even with just 1 property) is a good practice because we can add new properties to a response without breaking compatibility.
