### PR TITLE
Add support to filter arrays by file property

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1495,6 +1495,10 @@ definitions:
       - size
       # Code block
       - code_block
+      # UDF language
+      - udf_language
+      # Is dashboard
+      - is_dashboard
 
   PricingType:
     description: Pricing types
@@ -5047,6 +5051,14 @@ paths:
         collectionFormat: multi
         items:
           type: string
+      - name: file_property
+        in: query
+        description: file_property key-value pair (comma separated, i.e. key,value) to search for, more than one can be included
+        required: false
+        type: array
+        collectionFormat: multi
+        items:
+          type: string
     get:
       tags:
         - array
@@ -5140,6 +5152,14 @@ paths:
         collectionFormat: multi
         items:
           type: string
+      - name: file_property
+        in: query
+        description: file_property key-value pair (comma separated, i.e. key,value) to search for, more than one can be included
+        required: false
+        type: array
+        collectionFormat: multi
+        items:
+          type: string
     get:
       tags:
         - array
@@ -5228,6 +5248,14 @@ paths:
       - name: exclude_file_type
         in: query
         description: file_type to exclude matching array in results, more than one can be included
+        required: false
+        type: array
+        collectionFormat: multi
+        items:
+          type: string
+      - name: file_property
+        in: query
+        description: file_property key-value pair (comma separated, i.e. key,value) to search for, more than one can be included
         required: false
         type: array
         collectionFormat: multi


### PR DESCRIPTION
- Added `is_dashboard` file property to allow marking notebooks as dashboards
- Added a new `file_property` query param to array browser routes to allow filtering the results by file_property key-value pairs
- Added the missing `udf_language` FilePropertyName
