### PR TITLE
Revert "Add favorite indicator to ArrayInfo"

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1721,11 +1721,6 @@ definitions:
         type: boolean
         x-nullable: true
         example: false
-      is_favorite:
-        description: Indicates whether the array is in user favorites
-        type: boolean
-        x-omitempty: true
-        example: true
 
   ArrayInfoUpdate:
     description: metadata of an array


### PR DESCRIPTION
Reverts TileDB-Inc/TileDB-Cloud-API-Spec#262

Favorite indicator needs to exist per namespace