### PR TITLE
Remove result_format_version from all APIs

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1088,10 +1088,6 @@ definitions:
         $ref: "#/definitions/ResultFormat"
         description: type of results (native, i.e cloud pickle or json or arrow)
         x-omitempty: true
-      result_format_version:
-        type: string
-        description: string representing the serialization format to use, i.e. cloudpickle version or arrow IPC verison
-        x-omitempty: true
 
   PaginationMetadata:
     properties:
@@ -2020,10 +2016,6 @@ definitions:
         $ref: "#/definitions/ResultFormat"
         description: type of results (native, i.e cloud pickle or json or arrow)
         x-omitempty: true
-      result_format_version:
-        type: string
-        description: string representing the serialization format to use, i.e. cloudpickle version or arrow IPC verison
-        x-omitempty: true
       task_name:
         description: name of task, optional
         type: string
@@ -2076,10 +2068,6 @@ definitions:
       result_format:
         $ref: "#/definitions/ResultFormat"
         description: type of results (native, i.e cloud pickle or json or arrow)
-        x-omitempty: true
-      result_format_version:
-        type: string
-        description: string representing the serialization format to use, i.e. cloudpickle version or arrow IPC verison
         x-omitempty: true
       task_name:
         description: name of task, optional
@@ -2261,9 +2249,6 @@ definitions:
         $ref: "#/definitions/ResultFormat"
         description: type of results (native, i.e cloud pickle or json or arrow)
         x-omitempty: tru
-      result_format_version:
-        type: string
-        description: string representing the serialization format to use, i.e. cloudpickle version or arrow IPC verisonn
       init_commands:
         description: Queries or commands to run before main query
         type: array


### PR DESCRIPTION
`result_format_version` is currently unused; we just pass it among
our various components but never do anything with it. If we did live in
a world with multiple versions for a single result format, an empty
`result_format_version` would not be useful, since unless we define
the empty `result_format_version` as a v0 of sorts, we don’t actually
know what format it is and cannot unambiguously decode it.

Take, for example, the incompatiblity of pickles between py3.7 and 3.8:
it doesn’t matter that they’re both pickles; just that the one cannot
decode the other.

Incompatible result format versions are best represented as different
`result_format` values, since fundamentally we have to handle an
incompatible version the exact same way we would have to handle a
different format entirely. In situations where a later version of a
decoder may be able to decode an earlier version of a format, we can
manually track those mappings (because even `result_format_version`
provides no information about that right now).