### PR TITLE
Fix comment on QueryRanges to match REST-server implementation

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2129,7 +2129,7 @@ definitions:
         $ref: "#/definitions/QueryRanges"
       subarray:
         $ref: "#/definitions/UDFSubarray"
-        description: Subarray ranges to query, this is deprecate and `ranges` in UDFArrayDetails should be used instead.
+        description: Subarray ranges to query. This is deprecated. For single-array UDF, please use `ranges` in MultiArrayUDF; for multi-array UDF, please use `ranges` in UDFArrayDetails.
       buffers:
         description: List of buffers to fetch (attributes + dimensions). Deprecated please set arrays with UDFArrayDetails
         type: array


### PR DESCRIPTION
Within the REST server implementation, for `HandleArrayUDF()` (in contrast to `HandleMultiArrayUDF()`), a `models.UDFArrayDetails` struct is instantiated with its `Buffers` and `Ranges` attributes taken from the `MultiArrayUDF` struct from the JSON request of the incoming body. This behavior does not match the current API YAML comment affected by this PR.

Specifically, the incoming request looks like:

```
MultiArrayUDF {
  Buffers <-- is populated by the clients
  Ranges <-- is populated by the clients
  Arrays  <-- array of UDFArrayDetails
    [
      Buffers <-- not populated by the clients
      Ranges  <-- not populated by the clients
    ]
  ...
}
```

(See for example https://github.com/TileDB-Inc/TileDB-Cloud-Py/blob/master/tiledb/cloud/array.py#L465-L481 which demonstrates the behavior in the Python client. This may also be verified by inserting an `mitmproxy` between the REST client and the REST server, and looking at the JSON body.)

Within `HandleArrayUDF()` this is rewritten to:
```
MultiArrayUDF {
  Buffers
  Ranges
  Arrays
    [
      Buffers <-- copied in from MultiArrayUDF
      Ranges  <-- copied in from MultiArrayUDF
    ]
  ...
}
```

For `HandleMultiArrayUDF()`, `Buffers` and `Ranges` are taken from from the `Arrays` field of the `MultiArrayUDF`, where the clients have already populated them. This behavior does match the current API YAML comment affected by this PR.

```
MultiArrayUDF {
  Buffers <-- not used
  Ranges <-- not used
  Arrays
    [
      Buffers <-- populated by the clients
      Ranges  <-- populated by the clients
    ]
  ...
}
```
