### PR TITLE
Add is_dashboard parameters to listNotebookFavorites

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -5667,6 +5667,11 @@ paths:
   /notebooks/favorites:
     get:
       parameters:
+        - name: is_dashboard
+          in: query
+          description: return only dashboards
+          type: boolean
+          required: false
         - name: page
           in: query
           description: pagination offset


### PR DESCRIPTION
This is used to return only the favorites for dashboard