### PR TITLE
New API for MLmodel favorites

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2439,15 +2439,14 @@ definitions:
     description: A user-favorite MLModel item
     type: object
     properties:
-      id:
-        type: string
-        description: unique uuid of the favorite
-      created_at:
-        description: Datetime the favorite was created in UTC
-        type: string
-        format: date-time
       mlmodel_uuid:
         description: unique uuid of the MLModel
+        type: string
+      namespace:
+        description: the namespace of the MLModel
+        type: string
+      name:
+        description: the name of the MLModel
         type: string
 
   MLModelFavoritesData:
@@ -5858,30 +5857,13 @@ paths:
           required: false
       tags:
         - favorites
-      description: Fetch all ML models favorites of connected user
+      description: Fetch a page of ML models favorites of connected user
       operationId: listMLModelFavorites
       responses:
         200:
           description: Available ML models favorites are returned
           schema:
             $ref: "#/definitions/MLModelFavoritesData"
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
-    post:
-      tags:
-        - favorites
-      description: Add a new ML model favorite
-      operationId: addMLModelFavorite
-      parameters:
-        - in: body
-          name: body
-          schema:
-            $ref: '#/definitions/FavoriteCreate'
-      responses:
-        204:
-          description: Item added to favorites successfully
         default:
           description: error response
           schema:
@@ -5906,40 +5888,6 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /ml_models/favorites/{id}:
-    parameters:
-      - type: string
-        name: id
-        in: path
-        required: true
-        description: The uuid of the ML model favorite
-    get:
-      tags:
-        - favorites
-      description: Fetch specific ML model favorite of a user
-      operationId: getMLModelFavorite
-      responses:
-        200:
-          description: OK
-          schema:
-            $ref: '#/definitions/MLModelFavorite'
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
-    delete:
-      tags:
-        - favorites
-      description: Delete specific ML model favorite
-      operationId: deleteMLModelFavorite
-      responses:
-        204:
-          description: ML model favorite item deleted successfully
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
-
   /ml_models/favorites/{namespace}/{name}:
     parameters:
       - type: string
@@ -5956,12 +5904,36 @@ paths:
       tags:
         - favorites
       description: Fetch ML model favorite of a specific ML model
-      operationId: getMLModelFavoriteForMLModel
+      operationId: getMLModelFavorite
       responses:
         200:
           description: OK
           schema:
             $ref: '#/definitions/MLModelFavorite'
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+    post:
+      tags:
+        - favorites
+      description: Add a new ML model favorite
+      operationId: addMLModelFavorite
+      responses:
+        204:
+          description: Item added to favorites successfully
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+    delete:
+      tags:
+        - favorites
+      description: Delete specific ML model favorite
+      operationId: deleteMLModelFavorite
+      responses:
+        204:
+          description: ML model favorite item deleted successfully
         default:
           description: error response
           schema:


### PR DESCRIPTION
This is a proposal for a new API for favorites where we use `{namespace}/{name}` as much as possible to created, get and delete favorites.

The changes are implemented for ML models only as a proof of concept. We can compare this with the API of notebooks which is based on uuids