### PR TITLE
Make finish_time nullable

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1049,6 +1049,7 @@ definitions:
         description: Finish time RFC3339 for job
         type: string
         format: date-time
+        x-nullable: true
       cost:
         description: Total accumulated for task in USD, example is $0.12
         type: number


### PR DESCRIPTION
Finish_time is a nullable field but the spec isn't treating it as such.