### PR TITLE
Allow registration of multi-array UDFs

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -134,6 +134,8 @@ definitions:
     description: UDF Type
     type: string
     enum:
+      # multi_array
+      - multi_array
       # single_array
       - single_array
       # generic


### PR DESCRIPTION
Note the name `multi_array` rather than `multiple_array` since we already have
https://github.com/TileDB-Inc/TileDB-Cloud-API-Spec/blob/master/openapi-v1.yaml#L2094
et al.

Oddly, the `TileDB-Cloud-REST` repo already has this mod, ahead of spec ...

https://github.com/TileDB-Inc/TileDB-Cloud-REST/blob/master/models/udf_type.go#L27