### PR TITLE
Change GroupListing to support mixed content

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2719,6 +2719,20 @@ definitions:
         type: string
         description: output location of the exported file
 
+  GroupAncestor:
+    description: An ancestor of a group
+    type: object
+    properties:
+      id:
+        description: the globally unique id of the group
+        type: string
+      namespace:
+        description: The namespace of the group
+        type: string
+      name:
+        description: The name of the group
+        type: string
+
   Group:
     description: Attributes that describe the group itself, not any of the subgroups or assets
     type: object
@@ -2737,11 +2751,21 @@ definitions:
         description: A human readable description of the content of the group
         type: string
         x-omitempty: true
+      count:
+        description: The count of assets and direct subgroups of the group
+        type: integer
+        x-omitempty: false
+      ancestors:
+        description: The ancestors of the group. First is the top level group
+        type: array
+        items:
+          $ref: "#/definitions/GroupAncestor"
+        x-omitempty: false
     example:
       id: 0000-0001-0002-0003
       namespace: my-organization
       name: intro-to-genomics
-      path: /genomics-course/intro-to-genomics
+      count: 10
       description: contains arrays and notebooks for an 101 course on genomics with TileDB
 
   GroupCreate:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2824,6 +2824,19 @@ definitions:
           pagination_metadata:
             $ref: "#/definitions/PaginationMetadata"
 
+  GroupBrowserData:
+    description: Object including group info and pagination metadata
+    type: object
+    properties:
+      groups:
+        description: Group Info
+        type: array
+        x-omitempty: true
+        items:
+          $ref: "#/definitions/Group"
+      pagination_metadata:
+        $ref: "#/definitions/PaginationMetadata"
+
   TaskGraphLogStatus:
     description: The status of a given task graph execution.
     type: string
@@ -6366,7 +6379,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupListing'
+            $ref: '#/definitions/GroupBrowserData'
         default:
           description: error response
           schema:
@@ -6418,7 +6431,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupListing'
+            $ref: '#/definitions/GroupBrowserData'
         default:
           description: error response
           schema:
@@ -6470,7 +6483,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupListing'
+            $ref: '#/definitions/GroupBrowserData'
         default:
           description: error response
           schema:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2809,7 +2809,7 @@ definitions:
         $ref: "#/definitions/Group"
         x-omitempty: true
 
-  GroupListing:
+  GroupContents:
     description: The contents of a group i.e attributes, subgroups and assets
     allOf:
       - $ref: '#/definitions/Group'
@@ -6547,7 +6547,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupListing'
+            $ref: '#/definitions/GroupContents'
         default:
           description: error response
           schema:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2761,6 +2761,20 @@ definitions:
         items:
           $ref: "#/definitions/GroupAncestor"
         x-omitempty: false
+      share_count:
+        description: number of unique namespaces this array is shared with
+        type: number
+        format: integer
+      last_accessed:
+        description: Datetime group was last accessed in UTC
+        type: string
+        format: date-time
+      allowed_actions:
+        description: list of actions user is allowed to do on this group
+        type: array
+        x-omitempty: true
+        items:
+          $ref: "#/definitions/ArrayActions"
     example:
       id: 0000-0001-0002-0003
       namespace: my-organization

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2851,6 +2851,24 @@ definitions:
       pagination_metadata:
         $ref: "#/definitions/PaginationMetadata"
 
+  GroupAsset:
+    description: A group asset
+    type: object
+    properties:
+      namespace:
+        description: The namespace of the asset
+        type: string
+      name:
+        description: The name of the asset
+        type: string
+
+  GroupAssets:
+    description: An array of assets to be used with batch operations
+    type: array
+    x-omitempty: true
+    items:
+      $ref: "#/definitions/GroupAsset"
+
   TaskGraphLogStatus:
     description: The status of a given task graph execution.
     type: string
@@ -6638,6 +6656,47 @@ paths:
       responses:
         204:
           description: asset removed successfully
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+
+  /groups/{namespace}/{name}/assets:
+    parameters:
+      - name: namespace
+        type: string
+        in: path
+        required: true
+        description: The namespace of the group
+      - name: name
+        type: string
+        in: path
+        required: true
+        description: The name of the group
+      - name: GroupAssets
+        in: body
+        schema:
+          $ref: '#/definitions/GroupAssets'
+    post:
+      description: Batch operation, adds all the assets to a group
+      operationId: addAssets
+      tags:
+        - groups
+      responses:
+        204:
+          description: all assets added successfully
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+    delete:
+      description: Batch operation, removes all the assets from a group
+      operationId: removeAssets
+      tags:
+        - groups
+      responses:
+        204:
+          description: all assets removed successfully
         default:
           description: error response
           schema:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2772,24 +2772,31 @@ definitions:
       name: intro-to-genomics
       description: contains arrays and notebooks for an 101 course on genomics with TileDB
 
+  GroupEntry:
+    description: An entry of a group, that is a subgroup or an asset
+    type: object
+    properties:
+      asset:
+        description: If not empty, this entry is an asset
+        $ref: "#/definitions/ArrayInfo"
+        x-omitempty: true
+      group:
+        description: If not empty, this entry is a group
+        $ref: "#/definitions/Group"
+        x-omitempty: true
+
   GroupListing:
     description: The contents of a group i.e attributes, subgroups and assets
     allOf:
       - $ref: '#/definitions/Group'
       - type: object
         properties:
-          groups:
-            description: Contains one page of subgroups of the group.
+          entries:
+            description: Contains one page of group entries
             type: array
             x-omitempty: true
             items:
-              $ref: "#/definitions/Group"
-          assets:
-            description: Contains one page of assets of the group as ArrayInfos
-            type: array
-            x-omitempty: true
-            items:
-              $ref: "#/definitions/ArrayInfo"
+              $ref: "#/definitions/GroupEntry"
           pagination_metadata:
             $ref: "#/definitions/PaginationMetadata"
 
@@ -6365,6 +6372,7 @@ paths:
             - attributes # return only the group
             - groups     # return one page of subgroups
             - assets     # return one page of assets
+            - mixed      # return one page of assets and direct subgroups
         - name: page
           in: query
           description: pagination offset for assets

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -6296,19 +6296,142 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /groups/{namespace}:
-    parameters:
-      - name: namespace
-        type: string
-        in: path
-        required: true
-        description: The namespace to operate on
+  /groups/browser/owned:
     get:
-      description: Returns one page of top level groups in namespace.
-      operationId: listTopLevelGroups
+      description: Returns one page of owned groups.
+      operationId: listOwnedGroups
       tags:
         - groups
       parameters:
+        - name: namespace
+          in: query
+          description: namespace
+          required: false
+          type: string
+        - name: search
+          in: query
+          description: search string that will look at name of groups
+          type: string
+          required: false
+        - name: flat
+          in: query
+          description: if true, ignores the nesting of groups and searches all of them
+          type: boolean
+          required: false
+        - name: parent
+          in: query
+          description: search only the children of the groups with this uuid
+          type: string
+          required: false
+        - name: orderby
+          in: query
+          description: sort by which field valid values include name
+          type: string
+          required: false
+        - name: page
+          in: query
+          description: pagination offset
+          type: integer
+          required: false
+        - name: per_page
+          in: query
+          description: pagination limit
+          type: integer
+          required: false
+      responses:
+        200:
+          description: the group contents
+          schema:
+            $ref: '#/definitions/GroupListing'
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+
+  /groups/browser/shared:
+    get:
+      description: Returns one page of shared groups.
+      operationId: listSharedGroups
+      tags:
+        - groups
+      parameters:
+        - name: namespace
+          in: query
+          description: namespace
+          required: false
+          type: string
+        - name: search
+          in: query
+          description: search string that will look at name of groups
+          type: string
+          required: false
+        - name: flat
+          in: query
+          description: if true, ignores the nesting of groups and searches all of them
+          type: boolean
+          required: false
+        - name: parent
+          in: query
+          description: search only the children of the groups with this uuid
+          type: string
+          required: false
+        - name: orderby
+          in: query
+          description: sort by which field valid values include name
+          type: string
+          required: false
+        - name: page
+          in: query
+          description: pagination offset
+          type: integer
+          required: false
+        - name: per_page
+          in: query
+          description: pagination limit
+          type: integer
+          required: false
+      responses:
+        200:
+          description: the group contents
+          schema:
+            $ref: '#/definitions/GroupListing'
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+
+  /groups/browser/public:
+    get:
+      description: Returns one page of public groups.
+      operationId: listPublicGroups
+      tags:
+        - groups
+      parameters:
+        - name: namespace
+          in: query
+          description: namespace
+          required: false
+          type: string
+        - name: search
+          in: query
+          description: search string that will look at name of groups
+          type: string
+          required: false
+        - name: flat
+          in: query
+          description: if true, ignores the nesting of groups and searches all of them
+          type: boolean
+          required: false
+        - name: parent
+          in: query
+          description: search only the children of the groups with this uuid
+          type: string
+          required: false
+        - name: orderby
+          in: query
+          description: sort by which field valid values include name
+          type: string
+          required: false
         - name: page
           in: query
           description: pagination offset

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2786,6 +2786,9 @@ definitions:
     description: Initial attributes for the creation of a new group
     type: object
     properties:
+      name:
+        description: The name of the group. If must be unique within the group.
+        type: string
       parent:
         description: The name of the parent of the group. If empty, then the new group will be a top level group.
         type: string
@@ -6521,18 +6524,13 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /groups/{namespace}/{name}:
+  /groups/{namespace}:
     parameters:
       - name: namespace
         type: string
         in: path
         required: true
         description: The namespace of the group
-      - name: name
-        type: string
-        in: path
-        required: true
-        description: The name of the group
     post:
       description: Creates a new, empty group in the namespace.
       operationId: createGroup
@@ -6550,6 +6548,19 @@ paths:
           description: error response
           schema:
             $ref: "#/definitions/Error"
+
+  /groups/{namespace}/{name}:
+    parameters:
+      - name: namespace
+        type: string
+        in: path
+        required: true
+        description: The namespace of the group
+      - name: name
+        type: string
+        in: path
+        required: true
+        description: The name or id of the group
     get:
       description: Returns the contents, assets and subgroups, of the group
       operationId: listGroup

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2762,7 +2762,7 @@ definitions:
           $ref: "#/definitions/GroupAncestor"
         x-omitempty: false
       share_count:
-        description: number of unique namespaces this array is shared with
+        description: number of unique namespaces this group is shared with
         type: number
         format: integer
       last_accessed:


### PR DESCRIPTION
This is to support mixed content for groups.

I am not very fond of the model GroupEntry where `group` or `asset` maybe empty. However we currently use swagger 2 which does not have good support for polymorphic types (fixed in swagger 3) I am open to suggestions