### PR TITLE
Groups review

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1520,6 +1520,8 @@ definitions:
     description: File types represented as TileDB arrays
     type: string
     enum:
+      # Array
+      - array
       # Notebook
       - notebook
       # UDF
@@ -1528,6 +1530,8 @@ definitions:
       - ml_model
       # Files
       - file
+      # Groups
+      - group
 
   FilePropertyName:
     description: File property assigned to a specific file (array)
@@ -1543,6 +1547,8 @@ definitions:
       - udf_language
       # Is dashboard
       - is_dashboard
+      # Number of group contents
+      - group_content_count
 
   PricingType:
     description: Pricing types
@@ -2728,80 +2734,6 @@ definitions:
       output_uri:
         type: string
         description: output location of the exported file
-
-  Group:
-    description: Attributes that describe the group itself, not any of the subgroups or assets
-    type: object
-    properties:
-      id:
-        description: the globally unique id of the group
-        type: string
-        x-omitempty: true
-      namespace:
-        description: The namespace of the group
-        type: string
-      name:
-        description: The name of the group. It is unique within the namespace. No 2 groups can have the same name
-        type: string
-      description:
-        description: A human readable description of the content of the group
-        type: string
-        x-omitempty: true
-    example:
-      id: 0000-0001-0002-0003
-      namespace: my-organization
-      name: intro-to-genomics
-      path: /genomics-course/intro-to-genomics
-      description: contains arrays and notebooks for an 101 course on genomics with TileDB
-
-  GroupCreate:
-    description: Initial attributes for the creation of a new group
-    type: object
-    properties:
-      parent:
-        description: The name of the parent of the group. If empty, then the new group will be a top level group.
-        type: string
-      description:
-        description: A human readable description of the content of the group
-        type: string
-    example:
-      parent: genomics-course
-      description: contains arrays and notebooks for an 101 course on genomics with TileDB
-
-  GroupUpdate:
-    description: Updates for a group. New values for the attributes.
-    type: object
-    properties:
-      name:
-        description: The new name of the group
-        type: string
-      description:
-        description: A new human readable description of the content of the group
-        type: string
-    example:
-      name: intro-to-genomics
-      description: contains arrays and notebooks for an 101 course on genomics with TileDB
-
-  GroupListing:
-    description: The contents of a group i.e attributes, subgroups and assets
-    allOf:
-      - $ref: '#/definitions/Group'
-      - type: object
-        properties:
-          groups:
-            description: Contains one page of subgroups of the group.
-            type: array
-            x-omitempty: true
-            items:
-              $ref: "#/definitions/Group"
-          assets:
-            description: Contains one page of assets of the group as ArrayInfos
-            type: array
-            x-omitempty: true
-            items:
-              $ref: "#/definitions/ArrayInfo"
-          pagination_metadata:
-            $ref: "#/definitions/PaginationMetadata"
 
   TaskGraphLogStatus:
     description: The status of a given task graph execution.
@@ -6299,40 +6231,39 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
-  /groups/{namespace}:
+  /groups/{namespace}/{array}/create_or_register:
     parameters:
       - name: namespace
-        type: string
         in: path
+        description: namespace group is in (an organization name or user's username)
+        type: string
         required: true
-        description: The namespace to operate on
-    get:
-      description: Returns one page of top level groups in namespace.
-      operationId: listTopLevelGroups
+      - name: array
+        in: path
+        description: name/uri of group that is url-encoded
+        type: string
+        required: true
+    post:
+      description: create or register an group at a specified URI registered to the given namespace
       tags:
         - groups
+      operationId: createOrRegisterGroup
       parameters:
-        - name: page
-          in: query
-          description: pagination offset
-          type: integer
-          required: false
-        - name: per_page
-          in: query
-          description: pagination limit
-          type: integer
-          required: false
-      responses:
-        200:
-          description: the group contents
+        - name: group_info_update
+          in: body
+          description: metadata associated with group
           schema:
-            $ref: '#/definitions/GroupListing'
+            $ref: "#/definitions/ArrayInfoUpdate"
+          required: true
+      responses:
+        204:
+          description: group registered successfully
         default:
           description: error response
           schema:
             $ref: "#/definitions/Error"
 
-  /groups/{namespace}/{name}:
+  /groups/{namespace}/{name}/contents:
     parameters:
       - name: namespace
         type: string
@@ -6343,38 +6274,13 @@ paths:
         type: string
         in: path
         required: true
-        description: The name of the group
-    post:
-      description: Creates a new, empty group in the namespace.
-      operationId: createGroup
-      tags:
-        - groups
-      parameters:
-        - in: body
-          name: GroupCreate
-          schema:
-            $ref: '#/definitions/GroupCreate'
-      responses:
-        204:
-          description: group created successfully
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
+        description: The name or id of the group
     get:
       description: Returns the contents, assets and subgroups, of the group
-      operationId: listGroup
+      operationId: getGroupContents
       tags:
         - groups
       parameters:
-        - name: output
-          in: query
-          required: false
-          type: string
-          enum:
-            - attributes # return only the group
-            - groups     # return one page of subgroups
-            - assets     # return one page of assets
         - name: page
           in: query
           description: pagination offset for assets
@@ -6385,46 +6291,67 @@ paths:
           description: pagination limit for assets
           type: integer
           required: false
+        - name: search
+          in: query
+          description: search string that will look at name, namespace or description fields
+          required: false
+          type: string
+        - name: orderby
+          in: query
+          description: sort by which field valid values include last_accessed, size, name
+          required: false
+          type: string
+        - name: tag
+          in: query
+          description: tag to search for, more than one can be included
+          required: false
+          type: array
+          collectionFormat: multi
+          items:
+            type: string
+        - name: exclude_tag
+          in: query
+          description: tags to exclude matching array in results, more than one can be included
+          required: false
+          type: array
+          collectionFormat: multi
+          items:
+            type: string
+        - name: file_type
+          in: query
+          description: file_type to search for, more than one can be included
+          required: false
+          type: array
+          collectionFormat: multi
+          items:
+            type: string
+        - name: exclude_file_type
+          in: query
+          description: file_type to exclude matching array in results, more than one can be included
+          required: false
+          type: array
+          collectionFormat: multi
+          items:
+            type: string
+        - name: file_property
+          in: query
+          description: file_property key-value pair (comma separated, i.e. key,value) to search for, more than one can be included
+          required: false
+          type: array
+          collectionFormat: multi
+          items:
+            type: string
       responses:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupListing'
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
-    patch:
-      description: Changes attributes of the group
-      operationId: updateGroup
-      tags:
-        - groups
-      parameters:
-        - in: body
-          name: GroupUpdate
-          schema:
-            $ref: '#/definitions/GroupUpdate'
-      responses:
-        204:
-          description: attributes changed successfully
-        default:
-          description: error response
-          schema:
-            $ref: "#/definitions/Error"
-    delete:
-      description: Deletes the group and all the subgroups recursively. The assets are not deleted nor are not relocated to any other group
-      operationId: deleteGroup
-      tags:
-        - groups
-      responses:
-        204:
-          description: group deleted successfully
+            $ref: "#/definitions/ArrayBrowserData"
         default:
           description: error response
           schema:
             $ref: "#/definitions/Error"
 
-  /groups/{namespace}/{name}/{asset_namespace}/{asset_name}:
+  /groups/{namespace}/{name}/{asset_namespace}/{array}:
     parameters:
       - name: namespace
         type: string


### PR DESCRIPTION
Things to note:

- Current PR proposes abstracting groups as assets.
- Assets are arrays and groups can be treated like arrays.
- This simplifies listing of groups or mixed groups/arrays as they can reuse `ArrayBrowserData`.
- Groups can be created/registered and de-registered as normal arrays.
- Spec can be used to host mapping of arrays to groups in a database table or use Core Groups API to store/manipulate. them directly there.

`array` is now an asset type. In a follow up, we should abstract arrays as `assets`, in `v2`