### PR TITLE
Add initial messages for task graph registration.

### DIFF
--- a/task-graphs-v2.yaml
+++ b/task-graphs-v2.yaml
@@ -1,0 +1,370 @@
+# This is a separate file for working on task graph registration messages
+# and APIs so that in development it can be more easily navigated than
+# the full OpenAPI document.
+
+swagger: '2.0'
+info:
+  title: TileDB Cloud Task Graphs v2
+  description: >
+    Work-in-progress for the new version of the TileDB Cloud task graph API.
+  version: '0.0.1'
+
+produces:
+  - application/json
+consumes:
+  - application/json
+
+schemes:
+  - http
+  - https
+
+basePath: /
+
+definitions:
+
+  #
+  # Enums
+  #
+
+  ResultFormat:
+    description: 'Data format of a result'
+    type: string
+    enum:
+      - python_pickle
+      - r_serialization
+      - json
+      - arrow
+      - bytes
+        # Raw binary data, not interpreted by the loader.
+      - tiledb_json
+        # The format used to encode argument values for a task graph: JSON
+        # as deeply as possible, but any value that cannot be JSON-encoded
+        # is replaced with a TGArgument.
+      - native  # DEPRECATED. Use the language-specific values instead.
+      # TODO: Would it make sense to have an `auto` value?
+      # For instance, if a function results in a JSON-serializable value,
+      # it returns JSON (or tiledb_json), if it’s an Arrow value, ARROW,
+      # etc. and then pass that information back to the UDF environment?
+
+  UDFLanguage:
+    description: 'UDF runtime language'
+    type: string
+    enum:
+      - r
+      - python
+
+  #
+  # Graph structure
+  #
+
+  RegisteredTaskGraph:
+    description: >
+      The structure and metadata of a task graph that can be stored
+      on TileDB Cloud and executed by users who have access to it.
+    type: object
+    properties:
+      uuid:
+        type: string
+        description: A server-assigned unique ID for the UDF, in UUID format.
+      namespace:
+        type: string
+        description: The namespace that owns this task graph log.
+      name:
+        type: string
+        description: >
+          The name of this graph, to appear in URLs.
+          Must be unique per-namespace.
+      readme:
+        type: string
+        description: Documentation for the task graph, in Markdown format.
+      license_id:
+        type: string
+        x-nullable: True
+        description: SPDX license identifier.
+      license_text:
+        type: string
+        x-nullable: True
+        description: Full text of the license.
+      tags:
+        type: array
+        x-nullable: False
+        description: Optional tags to classify the graph.
+        items:
+          type: string
+          description: Unaccented, lowercase, hyphenated Latin characters.
+      nodes:
+        type: array
+        items:
+          $ref: '#/definitions/RegisteredTaskGraphNode'
+        description: >
+          The structure of the graph, in the form of the nodes that make it up.
+          As with `TaskGraphLog`, nodes must topologically sorted, so that any
+          node appears after all the nodes it depends on.
+      # Potential way to deduplicate identical code blocks.
+      # Not in initial version to keep it simpler.
+      # executables:
+      #   type: object
+      #   description: >
+      #     A dictionary of ID to base64-encoded executable code block.
+      #     Used to deduplicate code blocks shared by multiple Nodes.
+
+  RegisteredTaskGraphNode:
+    description: >
+      Information about a single node within a registered task graph.
+      A single node represents one piece of data or a computational step;
+      either as an input value, a data source, or a computation that acts upon
+      earlier nodes. The structure parallels the existing
+      `TaskGraphNodeMetadata`.
+    type: object
+    properties:
+      client_node_id:
+        type: string
+        description: The client-generated UUID of the given graph node.
+      name:
+        type: string
+        x-nullable: true
+        description: >
+          A client-specified name for the node. If provided, this must be
+          unique.
+      depends_on:
+        type: array
+        items:
+          type: string
+        description: >
+          The client_node_uuid of each node that this node depends upon.
+          Used to define the structure of the graph.
+      array_node:
+        $ref: '#/definitions/UDFArrayDetails'
+      input_node:
+        $ref: '#/definitions/TGInputNodeData'
+      sql_node:
+        $ref: '#/definitions/TGSQLNodeData'
+      udf_node:
+        $ref: '#/definitions/TGUDFNodeData'
+
+  TGInputNodeData:
+    description: >
+      Specifies that a node is an “input value”, allowing for parameterized
+      task graphs. An input node may not depend upon any other nodes.
+    type: object
+    x-nullable: True
+    properties:
+      default_value:
+        $ref: '#/definitions/TGImmediateValue'
+      result_format:
+        $ref: '#/definitions/ResultFormat'
+      datatype:
+        description: >
+          An annotation of what datatype this node is supposed to be.
+          Conventionally, this is a Python-format type annotation,
+          but it’s purely for documentation purposes and not validated.
+        type: string
+        x-nullable: true
+
+
+  TGSQLNodeData:
+    description: >
+      A node specifying an SQL query to execute in TileDB Cloud.
+    type: object
+    x-nullable: true
+    properties:
+      init_commands:
+        description: The commands to execute before running the query itself.
+        type: array
+        items:
+          type: string
+      query:
+        description: The text of the SQL query to execute.
+        type: string
+      parameters:
+        description: >
+          The parameters to substitute in for arguments in the `query`.
+          Fixed-length. Arguments must be in JSON format.
+        type: array
+        items:
+          $ref: '#/definitions/TGArgument'
+      result_format:
+        $ref: '#/definitions/ResultFormat'
+
+  TGUDFNodeData:
+    description: A node specifying the execution of a user-defined function.
+    type: object
+    x-nullable: true
+    properties:
+      registered_udf_name:
+        description: >
+          If set, the registered UDF to execute. Either this or
+          `executable_code` should be set, but not both.
+        type: string
+        x-nullable: true
+      executable_code:
+        description: >
+          If set, the base64 serialization of the code for this step, encoded
+          in a language-specific format (e.g. Pickle for Python, serialization
+          for R).
+        type: string
+        x-nullable: true
+      environment:
+        $ref: '#/definitions/TGUDFEnvironment'
+      arguments:
+        description: >
+          The arguments to a UDF function. This encompasses both named and
+          positional arguments. The format is designed to provide compatibility
+          across languages like Python which have a fairly traditional split
+          between positional arguments and named arguments, and languages like R
+          which has a rather unique way of specifying arguments.
+
+          For Python (and most other languages), all positional arguments will
+          come before all named arguments (if any are present):
+
+              // fn(arg1, arg2, arg3)
+              [
+                {value: arg1},
+                {value: arg2},
+                {value: arg3},
+              ]
+              // fn(arg1, arg2, n=kw1, a=kw2)
+              [
+                {value: arg1},
+                {value: arg2},
+                {name: "n", value: kw1},
+                {name: "a", value: kw2},
+              ]
+              // fn(kw=k1, only=k2)
+              [
+                {name: "kw", value: k1},
+                {name: "only", value: k2},
+              ]
+
+          However, in R, named and positional arguments may be intermixed
+          freely:
+
+              // fn(arg, n=kw1, arg2)
+              [
+                {value: arg},
+                {name: "n", value: kw1},
+                {value: arg2},
+              ]
+        type: array
+        items:
+          $ref: '#/definitions/TGUDFArgument'
+
+  TGUDFArgument:
+    description: >
+      A single argument to a UDF. This may represent a positional argument or
+      a named argument, depending upon whether `name` is set.
+    type: object
+    properties:
+      name:
+        description: The name of the argument, if present.
+        type: string
+        x-nullable: true
+      value:
+        $ref: '#/definitions/TGArgument'
+
+  TGUDFEnvironment:
+    description: Metadata about the environment where we want to execute a UDF.
+    type: object
+    properties:
+      language:
+        $ref: '#/definitions/UDFLanguage'
+      image_name:
+        description: >
+          The name of the image to use for the execution environment.
+
+
+  #
+  # Parameters
+  #
+
+  TGArgument:
+    description: >
+      An argument provided to a node. This is one of a direct value (i.e.,
+      a raw JSON value) or a `TGSentinel`.
+
+      For example this Python value:
+
+          {"a": [1, "pipe", range(30), None], "b": b"bytes"}
+
+      is encoded thusly (with included comments):
+
+          {  // A dictionary with string keys is JSON-encodable.
+            "a": [  // As is a list.
+              1,
+              "pipe",
+              {"__tiledb_sentinel__": {  // A `range` is replaced with its pickle.
+                "immediate": {
+                  "format": "python_pickle",
+                  "base64_data": "gASVIAAAAAAAAACMCGJ1aWx0aW5zlIwFcmFuZ2WUk5RLAEseSwGHlFKULg=="
+                }
+              }},
+              null
+            ],
+            "b": {"__tiledb_sentinel__": {  // Raw binary data is encoded into base64.
+              "immediate": {
+                "format": "bytes",
+                "base64_data": "Ynl0ZXM="
+              }
+            }}
+          }
+
+
+  # The below messages are not used directly in any API definitions,
+  # but are included as documentation of data encodings.
+
+  TGSentinel:
+    description: >
+      A sentinel value used to replace a value in a call that is made.
+      This will be replaced with the actual value to be sent to the UDF
+      environment, either by the server or the client.
+    type: object
+    properties:
+      __tiledb_sentinel__:
+        $ref: '#/definitions/TGSentinelValue'
+  TGSentinelValue:
+    description: >
+      The key that indicates that this value is not to be passed directly to
+      a UDF, but is instead some kind of upstream node or other special value.
+      Exactly one of these keys should be set.
+    type: object
+    properties:
+      node_output:
+        type: string
+        x-nullable: true
+        description: Substitutes the value of this node at call time.
+      array:
+        $ref: '#/definitions/TGArrayNodeData'
+      immediate:
+        $ref: '#/definitions/TGImmediateValue'
+      __escape__:
+        x-nullable: true
+        description: >
+          “Escape sequence” for if the user has a dictionary with
+          a `__tiledb_sentinel__` key.
+
+  TGImmediateValue:
+    description: >
+      An immediate value (i.e., not a node output) to be passed to an argument
+      that cannot be encoded in pure JSON. This is also used server-side to
+      subsitute in values when filling in stored parameters.
+    type: object
+    x-nullable: true
+    properties:
+      format:
+        $ref: '#/definitions/ResultFormat'
+      base64_data:
+        description: >
+          The binary data of the value itself, base64-encoded.
+        type: string
+
+  #
+  # Placeholder
+  #
+
+  UDFArrayDetails:
+    description: >
+      Placeholder to reserve the `UDFArrayDetails` name before merging these
+      messages into `openapi-v1.yaml`.
+
+# Empty paths object to make this a valid OpenAPI document before merging.
+paths: {}

--- a/task-graphs-v2.yaml
+++ b/task-graphs-v2.yaml
@@ -150,9 +150,7 @@ definitions:
     x-nullable: True
     properties:
       default_value:
-        $ref: '#/definitions/TGImmediateValue'
-      result_format:
-        $ref: '#/definitions/ResultFormat'
+        $ref: '#/definitions/TGArgument'
       datatype:
         description: >
           An annotation of what datatype this node is supposed to be.
@@ -174,7 +172,9 @@ definitions:
         items:
           type: string
       query:
-        description: The text of the SQL query to execute.
+        description: >
+          The text of the SQL query to execute. Parameters are substituted in
+          for `?`s, just as in a regular MariaDB query.
         type: string
       parameters:
         description: >
@@ -193,8 +193,9 @@ definitions:
     properties:
       registered_udf_name:
         description: >
-          If set, the registered UDF to execute. Either this or
-          `executable_code` should be set, but not both.
+          If set, the name of the registered UDF to execute, in the format
+          `namespace/name`. Either this or `executable_code` should be set,
+          but not both.
         type: string
         x-nullable: true
       executable_code:
@@ -333,7 +334,7 @@ definitions:
         x-nullable: true
         description: Substitutes the value of this node at call time.
       array:
-        $ref: '#/definitions/TGArrayNodeData'
+        $ref: '#/definitions/UDFArrayDetails'
       immediate:
         $ref: '#/definitions/TGImmediateValue'
       __escape__:


### PR DESCRIPTION
These messages should make for a complete and unambiguous format
to represent a task graph and each node therein. It is currently in a
separate file for ease of reading, but will be moved into
`openapi-v1.yaml` when the rest of the API is defined.