### PR TITLE
Replace 202 with 204 in UDF deletion call.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -5105,8 +5105,8 @@ paths:
         - udf
       operationId: deleteUDFInfo
       responses:
-        202:
-          description: UDF delete successfully
+        204:
+          description: UDF deleted successfully
         default:
           description: error response
           schema:


### PR DESCRIPTION
When deleting a UDF, we don’t return a 202, we return a 204.
This updates the spec to reflect that.