### PR TITLE
Update MultiArrayUDF to accept new-style argument passing.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2113,6 +2113,16 @@ definitions:
     description: Contains array details for multi-array query including uri, ranges buffers
     type: object
     properties:
+      parameter_id:
+        description: >
+          An optional client-generated identifier to distinguish between
+          multiple range/buffer requests from the same array in the same call.
+
+          This may be set for MultiArrayUDFs that use the `argument_json` style
+          of passing arrays.
+        type: string
+        x-nullable: true
+        x-omitempty: true
       uri:
         description: array to set ranges and buffers on, must be in tiledb:// format
         type: string
@@ -2153,15 +2163,32 @@ definitions:
         description: optional raw text to store of serialized function, used for showing in UI
       result_format:
         $ref: "#/definitions/ResultFormat"
-        description: type of results (native, i.e cloud pickle or json or arrow)
-        x-omitempty: true
       task_name:
         description: name of task, optional
         type: string
       argument:
         type: string
-        description: Argument(s) to pass to UDF function, tuple or list of args/kwargs which can be in native or JSON format
+        description: >
+          Deprecated: Prefer to use `argument_json` instead.
+
+          Argument(s) to pass to UDF function, tuple or list of args/kwargs
+          which can be in native or JSON format
         x-omitempty: true
+      arguments_json:
+        type: array
+        description: >
+          A series of key-value pairs to be passed as arguments into the UDF.
+          See `TGUDFNodeData.arguments` for more information.
+
+          If this format is used to pass arguments, arrays will be passed into
+          the UDF as specified by the Node placeholders passed in here, rather
+          than the classic method of putting all array arguments in the first
+          parameter.
+
+          Either this or `argument` should be set.
+        items:
+          $ref: '#/definitions/TGUDFArgument'
+        x-nullable: true
       stored_param_uuids:
         type: array
         items:
@@ -2811,6 +2838,12 @@ definitions:
           pagination_metadata:
             $ref: "#/definitions/PaginationMetadata"
 
+  #
+  # Task graph messages
+  #
+
+  # Task graph logs
+
   TaskGraphLogStatus:
     description: The status of a given task graph execution.
     type: string
@@ -2940,6 +2973,52 @@ definitions:
           $ref: '#/definitions/TaskGraphLog'
       pagination_metadata:
         $ref: '#/definitions/PaginationMetadata'
+
+  # Registered task graphs
+
+  TGUDFArgument:
+    description: >
+      A single argument to a UDF. This may represent a positional argument or
+      a named argument, depending upon whether `name` is set.
+    type: object
+    properties:
+      name:
+        description: The name of the argument, if present.
+        type: string
+        x-nullable: true
+      value:
+        $ref: '#/definitions/TGArgValue'
+
+  TGArgValue:
+    description: >
+      An argument provided to a node. This is one of a direct value (i.e.,
+      a raw JSON value) or a `TGSentinel`.
+
+      For example this Python value:
+
+          {"a": [1, "pipe", range(30), None], "b": b"bytes"}
+
+      is encoded thusly (with included comments):
+
+          {  // A dictionary with string keys is JSON-encodable.
+            "a": [  // As is a list.
+              1,
+              "pipe",
+              {"__tiledb_sentinel__": {  // A `range` is replaced with its pickle.
+                "immediate": {
+                  "format": "python_pickle",
+                  "base64_data": "gASVIAAAAAAAAACMCGJ1aWx0aW5zlIwFcmFuZ2WUk5RLAEseSwGHlFKULg=="
+                }
+              }},
+              null
+            ],
+            "b": {"__tiledb_sentinel__": {  // Raw binary data is encoded into base64.
+              "immediate": {
+                "format": "bytes",
+                "base64_data": "Ynl0ZXM="
+              }
+            }}
+          }
 
 paths:
   /.stats:

--- a/task-graphs-v2.yaml
+++ b/task-graphs-v2.yaml
@@ -39,7 +39,7 @@ definitions:
       - tiledb_json
         # The format used to encode argument values for a task graph: JSON
         # as deeply as possible, but any value that cannot be JSON-encoded
-        # is replaced with a TGArgument.
+        # is replaced with a TGArgValue.
       - native  # DEPRECATED. Use the language-specific values instead.
       # TODO: Would it make sense to have an `auto` value?
       # For instance, if a function results in a JSON-serializable value,
@@ -181,7 +181,7 @@ definitions:
     x-nullable: True
     properties:
       default_value:
-        $ref: '#/definitions/TGArgument'
+        $ref: '#/definitions/TGArgValue'
       datatype:
         description: >
           An annotation of what datatype this node is supposed to be.
@@ -213,7 +213,7 @@ definitions:
           Fixed-length. Arguments must be in JSON format.
         type: array
         items:
-          $ref: '#/definitions/TGArgument'
+          $ref: '#/definitions/TGArgValue'
       result_format:
         $ref: '#/definitions/ResultFormat'
 
@@ -292,7 +292,7 @@ definitions:
         type: string
         x-nullable: true
       value:
-        $ref: '#/definitions/TGArgument'
+        $ref: '#/definitions/TGArgValue'
 
   TGUDFEnvironment:
     description: Metadata about the environment where we want to execute a UDF.
@@ -309,7 +309,7 @@ definitions:
   # Parameters
   #
 
-  TGArgument:
+  TGArgValue:
     description: >
       An argument provided to a node. This is one of a direct value (i.e.,
       a raw JSON value) or a `TGSentinel`.
@@ -339,7 +339,6 @@ definitions:
               }
             }}
           }
-
 
   # The below messages are not used directly in any API definitions,
   # but are included as documentation of data encodings.


### PR DESCRIPTION
This updates `MultiArrayUDF` to accept arguments passed in the
`TGUDFArgument` format. This includes:

- Renames `TGArgument` to `TGArgValue` because `TGUDFArgument` and
  `TGArgument` would be a nightmare to keep apart.
- Adds the `TGUDFArgument` and `TGArgValue` types to the API.
- Adding `arguments_json` to `MultiArrayUDF`, so that the TGUDFArgument
  parameters can be encoded.
- Adding a `parameter_id` to `UDFArrayDetails`, so that users can pass
  multiple ranges across the same array (if you want to query two
  completely disjoint sets of coordinates, e.g. separate bounding boxes
  around North America and Africa on latlng-based geodata).

---

Continuing the process of integrating the new API types, little by little...