### PR TITLE
Add TaskGraphRunLocation to distinguish local nodes.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3219,6 +3219,22 @@ definitions:
 
   # Task graph logs
 
+  TaskGraphLogRunLocation:
+    description: >
+      The location where an individual node of a task graph is executed.
+    type: string
+    enum:
+      - server
+        # The node is executed server-side. This node will appear in the
+        # ArrayTask logs.
+      - client
+        # The node is executed client-side. This node will NOT appear in the
+        # ArrayTask logs since no action will have been performed.
+      - virtual
+        # The node is not executed at all. This node represents an input or
+        # other node that is a component of the graph but is not a true step
+        # that actually executes code.
+
   TaskGraphLogStatus:
     description: The status of a given task graph execution.
     type: string
@@ -3323,6 +3339,8 @@ definitions:
         description: >
           The client_node_uuid of each node that this node depends upon.
           Used to define the structure of the graph.
+      run_location:
+        $ref: '#/definitions/TaskGraphLogRunLocation'
       executions:
         type: array
         items:


### PR DESCRIPTION
Currently, the UI can't tell between a task graph node that was executed
client-side versus a node that will be executed server-side but hasn't
yet run, leaving difficult-to-parse "idle" nodes across the graph in
situations where a user executes part of a task graph locally.

This creates an enum that allows us to distinguish server-side nodes
from client-side nodes from (forthcoming) "virtual" nodes that represent
data in the graph that is not actually "executed".