### PR TITLE
Remove parent parameter

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -744,9 +744,6 @@ definitions:
           name:
             description: The name of the group. If must be unique within the group.
             type: string
-          parent:
-            description: The unique name or id of the parent of the group. If empty, then the new group will be a top level group.
-            type: string
           uri:
             description: uri of group.
             type: string


### PR DESCRIPTION
Parent parameter is not allowed.

Normal flow will be:
- Create empty group
- Register empty group as a member to another group