### PR TITLE
Upon array registration return ArrayInfo

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -5,13 +5,13 @@ info:
   version: 2.2.19
 
 produces:
-- application/json
+  - application/json
 consumes:
-- application/json
+  - application/json
 
 schemes:
-- http
-- https
+  - http
+  - https
 
 basePath: /v1
 
@@ -23,14 +23,14 @@ securityDefinitions:
     in: header
     name: X-TILEDB-REST-API-KEY
   OAuth2:
-      type: oauth2
-      flow: accessCode
-      authorizationUrl: https://oauth2.tiledb.com/oauth2/authorize
-      tokenUrl: https://oauth2.tiledb.com/oauth2/token
-      scopes:
-        read: Grants read access
-        write: Grants write access
-        admin: Grants read and write access to administrative information
+    type: oauth2
+    flow: accessCode
+    authorizationUrl: https://oauth2.tiledb.com/oauth2/authorize
+    tokenUrl: https://oauth2.tiledb.com/oauth2/token
+    scopes:
+      read: Grants read access
+      write: Grants write access
+      admin: Grants read and write access to administrative information
 
 security:
   - BasicAuth: []
@@ -142,7 +142,7 @@ definitions:
       - generic
 
   ResultFormat:
-    description: 'Data format of a result'
+    description: "Data format of a result"
     type: string
     enum:
       - python_pickle
@@ -155,7 +155,7 @@ definitions:
         # The format used to encode argument values for a task graph: JSON
         # as deeply as possible, but any value that cannot be JSON-encoded
         # is replaced with a TGArgValue.
-      - native  # DEPRECATED. Use the language-specific values instead.
+      - native # DEPRECATED. Use the language-specific values instead.
 
   Layout:
     description: Layout of array
@@ -198,7 +198,7 @@ definitions:
     description: TileDB filter types
     type: string
     enum:
-       # No-op filter
+      # No-op filter
       - FILTER_NONE
       # Gzip compressor
       - FILTER_GZIP
@@ -275,7 +275,7 @@ definitions:
     description: actions a user can take on an organization
     type: string
     enum:
-       # Fetch details about namespace and read arrays in namespace
+      # Fetch details about namespace and read arrays in namespace
       - read
       # Write to arrays inside namespace
       - write
@@ -578,7 +578,7 @@ definitions:
         x-omitempty: true
         items:
           type: integer
-        example: [1,3,0]
+        example: [1, 3, 0]
       arrayType:
         $ref: "#/definitions/ArrayType"
         description: Type of array
@@ -612,7 +612,7 @@ definitions:
         items:
           $ref: "#/definitions/Attribute"
       allowsDuplicates:
-        description:  True if the array allows coordinate duplicates. Applicable only to sparse arrays.
+        description: True if the array allows coordinate duplicates. Applicable only to sparse arrays.
         type: boolean
     x-go-type:
       import:
@@ -774,7 +774,7 @@ definitions:
         $ref: "#/definitions/Subarray"
       readState:
         description: To handle incomplete read queries.
-        $ref: '#/definitions/ReadState'
+        $ref: "#/definitions/ReadState"
       varOffsetsMode:
         description: The offsets format (bytes or elements) to be used.
         type: string
@@ -944,21 +944,21 @@ definitions:
       array_task_id:
         description: UUID of associated array task
         type: string
-        example:  "00000000-0000-0000-0000-000000000000"
+        example: "00000000-0000-0000-0000-000000000000"
       id:
         description: ID of the activity
         type: string
-        example:  "00000000-0000-0000-0000-000000000000"
+        example: "00000000-0000-0000-0000-000000000000"
       query_ranges:
         description: ranges for query
         x-omitempty: true
         type: string
-        example: "{\"rows\":[{\"start\": 1, \"end\": 1},{\"start\": 3, \"end\": 4}],\"cols\":[{\"start\": 1, \"end\": 4}]}"
+        example: '{"rows":[{"start": 1, "end": 1},{"start": 3, "end": 4}],"cols":[{"start": 1, "end": 4}]}'
       query_stats:
         description: stats for query
         x-omitempty: true
         type: string
-        example: "{\"timers\": {\"Context.StorageManager.read_load_array_schema_from_uri.sum\": 0.0255293, \"...\": \"...\"}, \"counters\": {\"Context.StorageManager.read_unfiltered_byte_num\": 191, \"...\": \"...\"}}"
+        example: '{"timers": {"Context.StorageManager.read_load_array_schema_from_uri.sum": 0.0255293, "...": "..."}, "counters": {"Context.StorageManager.read_unfiltered_byte_num": 191, "...": "..."}}'
 
   ArrayTaskType:
     description: Synchronous Task Type
@@ -1020,16 +1020,13 @@ definitions:
         $ref: "#/definitions/DomainArray"
         example:
           - Dim1:
-              Int64:
-                0
+              Int64: 0
                 10
             Dim2:
-              Int64:
-                20
+              Int64: 20
                 22
             Dim3:
-              Int64:
-                10000
+              Int64: 10000
                 10100
       memory:
         description: memory allocated to task in bytes
@@ -1273,7 +1270,7 @@ definitions:
           type: integer
 
   Error:
-    type:  object
+    type: object
     properties:
       code:
         type: integer
@@ -1297,7 +1294,7 @@ definitions:
         type: string
         minLength: 1
         maxLength: 63
-        pattern: "^[\\w.\\-]+$"   # only allows alphanumeric characters
+        pattern: "^[\\w.\\-]+$" # only allows alphanumeric characters
         description: username must be unique
         example: "username"
       password:
@@ -1421,7 +1418,7 @@ definitions:
         type: string
         minLength: 1
         maxLength: 63
-        pattern: "^[\\w.\\-]+$"   # only allows alphanumeric characters
+        pattern: "^[\\w.\\-]+$" # only allows alphanumeric characters
         description: organization name must be unique
       created_at:
         description: Datetime organization was created in UTC
@@ -1442,7 +1439,7 @@ definitions:
         type: array
         x-omitempty: true
         items:
-          $ref: '#/definitions/OrganizationUser'
+          $ref: "#/definitions/OrganizationUser"
       allowed_actions:
         description: list of actions user is allowed to do on this organization
         type: array
@@ -2109,7 +2106,6 @@ definitions:
         description: >
           If set, the client-defined ID of the node within this task's graph.
 
-
   UDFArrayDetails:
     description: Contains array details for multi-array query including uri, ranges buffers
     type: object
@@ -2188,7 +2184,7 @@ definitions:
 
           Either this or `argument` should be set.
         items:
-          $ref: '#/definitions/TGUDFArgument'
+          $ref: "#/definitions/TGUDFArgument"
         x-nullable: true
       stored_param_uuids:
         type: array
@@ -2237,7 +2233,6 @@ definitions:
         x-omitempty: true
         description: >
           If set, the client-defined ID of the node within this task's graph.
-
 
   UDFImage:
     description: Defines a set of images related to a specific name
@@ -2936,10 +2931,10 @@ definitions:
     properties:
       group:
         description: the metadata of the entry if it is a group, null if it is an array
-        $ref: '#/definitions/GroupInfo'
+        $ref: "#/definitions/GroupInfo"
       array:
         description: the metadata of the entry if it is an array, null if it is a group
-        $ref: '#/definitions/ArrayInfo'
+        $ref: "#/definitions/ArrayInfo"
 
   GroupContents:
     description: Object including a page of members of a group and pagination metadata
@@ -3138,7 +3133,7 @@ definitions:
         description: The name or id of the asset.
         type: string
       member_type:
-        $ref: '#/definitions/GroupMemberType'
+        $ref: "#/definitions/GroupMemberType"
 
   GroupChanges:
     description: A request to change the members of a group. Contains assets to add or remove.
@@ -3148,12 +3143,12 @@ definitions:
         description: the assets, arrays or groups, to add to the group.
         type: array
         items:
-          $ref: '#/definitions/GroupMember'
+          $ref: "#/definitions/GroupMember"
       remove:
         description: the assets, arrays or groups, to remove from the group.
         type: array
         items:
-          $ref: '#/definitions/GroupMember'
+          $ref: "#/definitions/GroupMember"
 
   GroupSharing:
     description: sharing state of a group with a namespace
@@ -3225,8 +3220,8 @@ definitions:
     type: string
     enum:
       - server
-        # The node is executed server-side. This node will appear in the
-        # ArrayTask logs.
+      # The node is executed server-side. This node will appear in the
+      # ArrayTask logs.
       - client
         # The node is executed client-side. This node will NOT appear in the
         # ArrayTask logs since no action will have been performed.
@@ -3309,11 +3304,11 @@ definitions:
           The end time of the task graph, recorded when the client reports
           completion.
       status:
-        $ref: '#/definitions/TaskGraphLogStatus'
+        $ref: "#/definitions/TaskGraphLogStatus"
       nodes:
         type: array
         items:
-          $ref: '#/definitions/TaskGraphNodeMetadata'
+          $ref: "#/definitions/TaskGraphNodeMetadata"
         description: >
           The structure of the graph. This is provided by the client
           when first setting up the task graph. Thereafter, it is read-only.
@@ -3340,11 +3335,11 @@ definitions:
           The client_node_uuid of each node that this node depends upon.
           Used to define the structure of the graph.
       run_location:
-        $ref: '#/definitions/TaskGraphLogRunLocation'
+        $ref: "#/definitions/TaskGraphLogRunLocation"
       executions:
         type: array
         items:
-          $ref: '#/definitions/ArrayTask'
+          $ref: "#/definitions/ArrayTask"
         readOnly: true
         description: >
           ArrayTasks representing each execution attempt for this node.
@@ -3363,9 +3358,9 @@ definitions:
         description: The requested task graph logs.
         type: array
         items:
-          $ref: '#/definitions/TaskGraphLog'
+          $ref: "#/definitions/TaskGraphLog"
       pagination_metadata:
-        $ref: '#/definitions/PaginationMetadata'
+        $ref: "#/definitions/PaginationMetadata"
 
   # Registered task graphs
 
@@ -3380,7 +3375,7 @@ definitions:
         type: string
         x-nullable: true
       value:
-        $ref: '#/definitions/TGArgValue'
+        $ref: "#/definitions/TGArgValue"
 
   TGArgValue:
     description: >
@@ -3617,36 +3612,36 @@ paths:
             $ref: "#/definitions/Error"
 
   /arrays/{namespace}/{array}/activity/{id}:
-      parameters:
-        - name: namespace
-          in: path
-          description: namespace array is in (an organization name or user's username)
-          type: string
-          required: true
-        - name: array
-          in: path
-          description: name/uri of array that is url-encoded
-          type: string
-          required: true
-        - name: id
-          in: path
-          description: ID of the activity
-          type: string
-          required: true
-      get:
-        description: get activity log by ID
-        tags:
-          - array
-        operationId: getActivityLogById
-        responses:
-          200:
-            description: array activity
-            schema:
-                $ref: "#/definitions/ArrayActivityLog"
-          default:
-            description: error response
-            schema:
-              $ref: "#/definitions/Error"
+    parameters:
+      - name: namespace
+        in: path
+        description: namespace array is in (an organization name or user's username)
+        type: string
+        required: true
+      - name: array
+        in: path
+        description: name/uri of array that is url-encoded
+        type: string
+        required: true
+      - name: id
+        in: path
+        description: ID of the activity
+        type: string
+        required: true
+    get:
+      description: get activity log by ID
+      tags:
+        - array
+      operationId: getActivityLogById
+      responses:
+        200:
+          description: array activity
+          schema:
+            $ref: "#/definitions/ArrayActivityLog"
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
 
   /arrays/{namespace}/{array}/deregister:
     parameters:
@@ -3837,8 +3832,10 @@ paths:
             $ref: "#/definitions/ArrayInfoUpdate"
           required: true
       responses:
-        204:
-          description: schema registered successfully
+        200:
+          description: array registered successfully
+          schema:
+          $ref: "#/definitions/ArrayInfo"
         default:
           description: error response
           schema:
@@ -4216,7 +4213,7 @@ paths:
             type: object
           examples:
             application/json:
-              data: "{\"a1\":[0,1,2,3,0,1,2,3]}"
+              data: '{"a1":[0,1,2,3,0,1,2,3]}'
 
         default:
           description: error response
@@ -4430,7 +4427,7 @@ paths:
         200:
           description: get array sample data
           schema:
-              $ref: "#/definitions/ArraySample"
+            $ref: "#/definitions/ArraySample"
           examples:
             application/json:
               dim1:
@@ -4498,7 +4495,7 @@ paths:
         200:
           description: get array metadata
           schema:
-              $ref: "#/definitions/ArrayMetadataJson"
+            $ref: "#/definitions/ArrayMetadataJson"
           examples:
             application/json:
               key1: 25
@@ -4544,7 +4541,7 @@ paths:
         200:
           description: get array non-empty domaim
           schema:
-              $ref: "#/definitions/NonEmptyDomainJson"
+            $ref: "#/definitions/NonEmptyDomainJson"
           examples:
             application/json:
               dim1:
@@ -5406,8 +5403,8 @@ paths:
           schema:
             type: array
             items:
-                  type: object
-                  additionalProperties: true
+              type: object
+              additionalProperties: true
         204:
           description: SQL executed successfully
           headers:
@@ -5744,7 +5741,7 @@ paths:
         200:
           description: status of running notebook
           schema:
-              $ref: "#/definitions/NotebookStatus"
+            $ref: "#/definitions/NotebookStatus"
         202:
           description: Notebook server is pending
         402:
@@ -6519,7 +6516,7 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/ArrayFavorite'
+            $ref: "#/definitions/ArrayFavorite"
         default:
           description: error response
           schema:
@@ -6621,7 +6618,7 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/NotebookFavorite'
+            $ref: "#/definitions/NotebookFavorite"
         default:
           description: error response
           schema:
@@ -6718,7 +6715,7 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/MLModelFavorite'
+            $ref: "#/definitions/MLModelFavorite"
         default:
           description: error response
           schema:
@@ -6815,7 +6812,7 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/UDFFavorite'
+            $ref: "#/definitions/UDFFavorite"
         default:
           description: error response
           schema:
@@ -7035,7 +7032,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupBrowserData'
+            $ref: "#/definitions/GroupBrowserData"
         default:
           description: error response
           schema:
@@ -7122,7 +7119,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupBrowserData'
+            $ref: "#/definitions/GroupBrowserData"
         default:
           description: error response
           schema:
@@ -7209,7 +7206,7 @@ paths:
         200:
           description: the group contents
           schema:
-            $ref: '#/definitions/GroupBrowserData'
+            $ref: "#/definitions/GroupBrowserData"
         default:
           description: error response
           schema:
@@ -7262,7 +7259,7 @@ paths:
         - in: body
           name: GroupChanges
           schema:
-            $ref: '#/definitions/GroupChanges'
+            $ref: "#/definitions/GroupChanges"
       responses:
         204:
           description: all changes applied successfully
@@ -7364,7 +7361,7 @@ paths:
         - in: body
           name: GroupRegister
           schema:
-            $ref: '#/definitions/GroupRegister'
+            $ref: "#/definitions/GroupRegister"
       responses:
         204:
           description: group created successfully
@@ -7389,7 +7386,7 @@ paths:
         - in: body
           name: GroupCreate
           schema:
-            $ref: '#/definitions/GroupCreate'
+            $ref: "#/definitions/GroupCreate"
       responses:
         204:
           description: group created successfully
@@ -7472,7 +7469,7 @@ paths:
         200:
           description: the group metadata
           schema:
-            $ref: '#/definitions/GroupInfo'
+            $ref: "#/definitions/GroupInfo"
         default:
           description: error response
           schema:
@@ -7486,7 +7483,7 @@ paths:
         - in: body
           name: GroupUpdate
           schema:
-            $ref: '#/definitions/GroupUpdate'
+            $ref: "#/definitions/GroupUpdate"
       responses:
         204:
           description: attributes changed successfully
@@ -7523,18 +7520,18 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/TaskGraphLog'
+            $ref: "#/definitions/TaskGraphLog"
       responses:
         201:
           description: >
             The task graph was created. The returned TaskGraphLog will include
             the data the client sent, with the server-defined fields added in.
           schema:
-            $ref: '#/definitions/TaskGraphLog'
+            $ref: "#/definitions/TaskGraphLog"
         default:
           description: error response
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
 
   /taskgraphs/logs:
     parameters:
@@ -7592,11 +7589,11 @@ paths:
         200:
           description: The task graph logs that matched the user's query.
           schema:
-            $ref: '#/definitions/TaskGraphLogsData'
+            $ref: "#/definitions/TaskGraphLogsData"
         default:
           description: error response
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
 
   /taskgraphs/{namespace}/logs/{id}:
     parameters:
@@ -7620,11 +7617,11 @@ paths:
         200:
           description: Information about the execution of a single task graph.
           schema:
-            $ref: '#/definitions/TaskGraphLog'
+            $ref: "#/definitions/TaskGraphLog"
         default:
           description: error response
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"
     patch:
       description: >
         Update information about a single task graph execution.
@@ -7639,7 +7636,7 @@ paths:
             that a client should need to make to a task graph log is to update
             its completion status to `succeeded`, `failed`, or `cancelled`.
           schema:
-            $ref: '#/definitions/TaskGraphLog'
+            $ref: "#/definitions/TaskGraphLog"
           required: true
       responses:
         204:
@@ -7647,4 +7644,4 @@ paths:
         default:
           description: error response
           schema:
-            $ref: '#/definitions/Error'
+            $ref: "#/definitions/Error"


### PR DESCRIPTION
This gives back the user the details including the array uuid for them to access. This is needed when registering arrays with duplicate names to be able to identify the newly registered array.