### PR TITLE
Change UDF copy response. Add UUID of copy

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2816,6 +2816,8 @@ definitions:
   UDFCopied:
     description: Copied udf uri and information
     type: object
+    required:
+      - id
     properties:
       output_uri:
         type: string
@@ -2826,6 +2828,11 @@ definitions:
       name:
         type: string
         description: name of the copied udf
+      id:
+        description: unique ID of the copied udf
+        type: string
+        example: "00000000-0000-0000-0000-000000000000"
+        x-omitempty: false
 
   GroupActions:
     description: actions a user can take on a group


### PR DESCRIPTION
Ref https://app.shortcut.com/tiledb-inc/story/17206/copy-udfs-with-the-same-name-should-be-accessed-by-uuid