### PR TITLE
Move task graph APIs over to the main spec.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3450,6 +3450,229 @@ definitions:
 
   # Registered task graphs
 
+  RegisteredTaskGraph:
+    description: >
+      The structure and metadata of a task graph that can be stored
+      on TileDB Cloud and executed by users who have access to it.
+    type: object
+    properties:
+      uuid:
+        type: string
+        description: A server-assigned unique ID for the UDF, in UUID format.
+      namespace:
+        type: string
+        description: The namespace that owns this task graph log.
+      name:
+        type: string
+        description: >
+          The name of this graph, to appear in URLs.
+          Must be unique per-namespace.
+      readme:
+        type: string
+        description: Documentation for the task graph, in Markdown format.
+      license_id:
+        type: string
+        x-nullable: True
+        description: SPDX license identifier.
+      license_text:
+        type: string
+        x-nullable: True
+        description: Full text of the license.
+      tags:
+        type: array
+        x-nullable: False
+        description: Optional tags to classify the graph.
+        items:
+          type: string
+          description: Unaccented, lowercase, hyphenated Latin characters.
+      nodes:
+        type: array
+        items:
+          $ref: '#/definitions/RegisteredTaskGraphNode'
+        description: >
+          The structure of the graph, in the form of the nodes that make it up.
+          As with `TaskGraphLog`, nodes must topologically sorted, so that any
+          node appears after all the nodes it depends on.
+
+  TaskGraphActions:
+    description: actions a user can take on a UDF
+    type: string
+    enum:
+      # Fetch task graph
+      - fetch_task_graph
+      # Share task graph with others
+      - share_task_graph
+
+  TaskGraphSharing:
+    description: details for sharing a given registered task graph
+    type: object
+    properties:
+      actions:
+        description: List of permitted actions
+        type: array
+        x-omitempty: true
+        items:
+          $ref: "#/definitions/TaskGraphActions"
+        example:
+          - fetch_task_graph
+          - share_task_graph
+      namespace:
+        description: namespace being granted array access can be a user or organization
+        type: string
+        example: "MyOrganization"
+      namespace_type:
+        description: details on if the namespace is a organization or user
+        type: string
+        example: "organization"
+
+  RegisteredTaskGraphNode:
+    description: >
+      Information about a single node within a registered task graph.
+      A single node represents one piece of data or a computational step;
+      either as an input value, a data source, or a computation that acts upon
+      earlier nodes. The structure parallels the existing
+      `TaskGraphNodeMetadata`.
+    type: object
+    properties:
+      client_node_id:
+        type: string
+        description: The client-generated UUID of the given graph node.
+      name:
+        type: string
+        x-nullable: true
+        description: >
+          A client-specified name for the node. If provided, this must be
+          unique.
+      depends_on:
+        type: array
+        items:
+          type: string
+        description: >
+          The client_node_uuid of each node that this node depends upon.
+          Used to define the structure of the graph.
+      array_node:
+        $ref: '#/definitions/UDFArrayDetails'
+      input_node:
+        $ref: '#/definitions/TGInputNodeData'
+      sql_node:
+        $ref: '#/definitions/TGSQLNodeData'
+      udf_node:
+        $ref: '#/definitions/TGUDFNodeData'
+
+  TGInputNodeData:
+    description: >
+      Specifies that a node is an “input value”, allowing for parameterized
+      task graphs. An input node may not depend upon any other nodes.
+    type: object
+    x-nullable: True
+    properties:
+      default_value:
+        $ref: '#/definitions/TGArgValue'
+      datatype:
+        description: >
+          An annotation of what datatype this node is supposed to be.
+          Conventionally, this is a Python-format type annotation,
+          but it’s purely for documentation purposes and not validated.
+        type: string
+        x-nullable: true
+
+  TGSQLNodeData:
+    description: >
+      A node specifying an SQL query to execute in TileDB Cloud.
+    type: object
+    x-nullable: true
+    properties:
+      init_commands:
+        description: The commands to execute before running the query itself.
+        type: array
+        items:
+          type: string
+      query:
+        description: >
+          The text of the SQL query to execute. Parameters are substituted in
+          for `?`s, just as in a regular MariaDB query.
+        type: string
+      parameters:
+        description: >
+          The parameters to substitute in for arguments in the `query`.
+          Fixed-length. Arguments must be in JSON format.
+        type: array
+        items:
+          $ref: '#/definitions/TGArgValue'
+      result_format:
+        $ref: '#/definitions/ResultFormat'
+
+  TGUDFNodeData:
+    description: A node specifying the execution of a user-defined function.
+    type: object
+    x-nullable: true
+    properties:
+      registered_udf_name:
+        description: >
+          If set, the name of the registered UDF to execute, in the format
+          `namespace/name`. Either this or `executable_code` should be set,
+          but not both.
+        type: string
+        x-nullable: true
+      executable_code:
+        description: >
+          If set, the base64 serialization of the code for this step, encoded
+          in a language-specific format (e.g. Pickle for Python, serialization
+          for R).
+        type: string
+        x-nullable: true
+      source_text:
+        description: >
+          Optionally, the source text for the code passed in `executable_code`.
+          *For reference only; only the code in `executable_code` is actually
+          executed.* This will be included in activity logs and may be useful
+          for debugging.
+        type: string
+      environment:
+        $ref: '#/definitions/TGUDFEnvironment'
+      arguments:
+        description: >
+          The arguments to a UDF function. This encompasses both named and
+          positional arguments. The format is designed to provide compatibility
+          across languages like Python which have a fairly traditional split
+          between positional arguments and named arguments, and languages like R
+          which has a rather unique way of specifying arguments.
+
+          For Python (and most other languages), all positional arguments will
+          come before all named arguments (if any are present):
+
+              // fn(arg1, arg2, arg3)
+              [
+                {value: arg1},
+                {value: arg2},
+                {value: arg3},
+              ]
+              // fn(arg1, arg2, n=kw1, a=kw2)
+              [
+                {value: arg1},
+                {value: arg2},
+                {name: "n", value: kw1},
+                {name: "a", value: kw2},
+              ]
+              // fn(kw=k1, only=k2)
+              [
+                {name: "kw", value: k1},
+                {name: "only", value: k2},
+              ]
+
+          However, in R, named and positional arguments may be intermixed
+          freely:
+
+              // fn(arg, n=kw1, arg2)
+              [
+                {value: arg},
+                {name: "n", value: kw1},
+                {value: arg2},
+              ]
+        type: array
+        items:
+          $ref: '#/definitions/TGUDFArgument'
+
   TGUDFArgument:
     description: >
       A single argument to a UDF. This may represent a positional argument or
@@ -3461,7 +3684,7 @@ definitions:
         type: string
         x-nullable: true
       value:
-        $ref: "#/definitions/TGArgValue"
+        $ref: '#/definitions/TGArgValue'
 
   TGArgValue:
     description: >
@@ -3478,21 +3701,44 @@ definitions:
             "a": [  // As is a list.
               1,
               "pipe",
-              {"__tiledb_sentinel__": {  // A `range` is replaced with its pickle.
-                "immediate": {
-                  "format": "python_pickle",
-                  "base64_data": "gASVIAAAAAAAAACMCGJ1aWx0aW5zlIwFcmFuZ2WUk5RLAEseSwGHlFKULg=="
-                }
-              }},
+              {  // A `range` is replaced with its pickle.
+                "__tdbudf__": "immediate",
+                "format": "python_pickle",
+                "base64_data": "gASVIAAAAAAAAACMCGJ1aWx0aW5zlIwFcmFuZ2WUk5RLAEseSwGHlFKULg=="
+              },
               null
             ],
-            "b": {"__tiledb_sentinel__": {  // Raw binary data is encoded into base64.
-              "immediate": {
-                "format": "bytes",
-                "base64_data": "Ynl0ZXM="
-              }
-            }}
+            "b": {  // Raw binary data is encoded into base64.
+              "__tdbudf__": "immediate"
+              "format": "bytes",
+              "base64_data": "Ynl0ZXM="
+            }
           }
+
+  TGUDFEnvironment:
+    description: Metadata about the environment where we want to execute a UDF.
+    type: object
+    properties:
+      language:
+        $ref: '#/definitions/UDFLanguage'
+      language_version:
+        description: >
+          The language version used to execute this UDF. Neither this nor
+          `language` needs to be set for registered UDFs, since the language
+          and version are stored server-side with the UDF itself.
+        type: string
+      image_name:
+        description: >
+          The name of the image to use for the execution environment.
+        type: string
+      resource_class:
+        description: >
+          The resource class to use for the UDF execution. Resource classes
+          define resource limits for memory and CPUs. If this is empty, then the
+          UDF will execute in the standard resource class of the TileDB Cloud
+          provider.
+        type: string
+        x-omitempty: true
 
 paths:
   /.stats:
@@ -7619,6 +7865,8 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  # Task graphs: Logs
+
   /taskgraphs/logs:
     parameters:
       - name: namespace
@@ -7758,6 +8006,152 @@ paths:
       responses:
         204:
           description: Status reported successfully.
+        default:
+          description: error response
+          schema:
+            $ref: '#/definitions/Error'
+
+  # Task graphs: Registration
+
+  /taskgraphs/{namespace}/registered/{name}:
+    parameters:
+      - name: namespace
+        in: path
+        description: The namespace that owns this registered UDF.
+        type: string
+        required: true
+      - name: name
+        in: path
+        description: The name of the registered task graph.
+        type: string
+        required: true
+    get:
+      description: >
+        Fetch the contents of this registered task graph.
+      operationId: getRegisteredTaskGraph
+      tags:
+        - registered_task_graphs
+      responses:
+        200:
+          description: The contents of the registered task graph.
+          schema:
+            $ref: '#/definitions/RegisteredTaskGraph'
+        default:
+          description: error response
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      description: >
+        Register a task graph in the given namespace, with the given name.
+      operationId: registerRegisteredTaskGraph
+      tags:
+        - registered_task_graphs
+      parameters:
+        - name: graph
+          in: body
+          description: Task graph to register.
+          schema:
+            $ref: '#/definitions/RegisteredTaskGraph'
+      responses:
+        204:
+          description: Task graph registered successfully.
+        default:
+          description: error response
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      description: >
+        Update the contents of an existing registered task graph.
+      operationId: updateRegisteredTaskGraph
+      tags:
+        - registered_task_graphs
+      parameters:
+        - name: graph
+          in: body
+          description: The new contents of the task graph.
+          schema:
+            $ref: '#/definitions/RegisteredTaskGraph'
+      responses:
+        204:
+          description: Task graph updated successfully.
+        default:
+          description: error response
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      description: >
+        Delete the given registered task graph.
+      operationId: deleteRegisteredTaskGraph
+      tags:
+        - registered_task_graphs
+      responses:
+        204:
+          description: Task graph successfully deleted.
+        default:
+          description: error response
+          schema:
+            $ref: '#/definitions/Error'
+
+  /taskgraphs/{namespace}/registered/{name}/share:
+    parameters:
+      - name: namespace
+        in: path
+        description: The namespace that owns the registered task graph.
+        type: string
+        required: true
+      - name: name
+        in: path
+        description: The name of the task graph.
+        type: string
+        required: true
+    get:
+      description: Get sharing policies for the task graph.
+      tags:
+        - registered_task_graphs
+      operationId: getRegisteredTaskGraphSharingPolicies
+      responses:
+        200:
+          description: List of all specific sharing policies
+          schema:
+            type: array
+            x-omitempty: true
+            items:
+              $ref: '#/definitions/TaskGraphSharing'
+        404:
+          description: >
+            The task graph does not exist (or the user does not have permission
+            to view policies)
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: error response
+          schema:
+            $ref: '#/definitions/Error'
+    patch:
+      description: Share a task graph.
+      tags:
+        - registered_task_graphs
+      operationId: shareRegisteredTaskGraph
+      parameters:
+        - name: task_graph_sharing
+          in: body
+          description: >
+            Namespace and list of permissions to share with.
+            An empty list of permissions will remove the namespace;
+            if permissions already exist they will be deleted then
+            new ones added. In the event of a failure, the new policies
+            will be rolled back to prevent partial policies, and it's likely
+            the UDF will not be shared with the namespace at all.
+          schema:
+            $ref: '#/definitions/TaskGraphSharing'
+          required: true
+      responses:
+        204:
+          description: UDF shared successfully
+        404:
+          description: UDF does not exist or user does not have permissions to share UDF
+          schema:
+            $ref: '#/definitions/Error'
         default:
           description: error response
           schema:


### PR DESCRIPTION
Because the task graph APIs are reasonably finalized, they're now ready
to be moved over to the main API specification.