### PR TITLE
Add `RESOURCES_UNAVAILABLE` array task status

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -977,9 +977,10 @@ definitions:
       - FAILED
       - COMPLETED
       - RUNNING
-      - DENIED
+      - RESOURCES_UNAVAILABLE
       - UNKNOWN
       - CANCELLED
+      - DENIED  # Deprecated; used to mean RESOURCES_UNAVAILABLE.
 
   ArrayTaskLog:
     description: Array task stderr/stdout logs


### PR DESCRIPTION
This new status will be used instead of `DENIED` to make task entries
easier to understand.

[sc-18566]