### PR TITLE
Add `CLIENT_COMPUTATION` ArrayTaskType.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -968,6 +968,7 @@ definitions:
       - UDF
       - QUERY
       - GENERIC_UDF
+      - CLIENT_COMPUTATION
 
   ArrayTaskStatus:
     description: Status of array task


### PR DESCRIPTION
Because we need to use ArrayTasks to report client-side progress on
locally-executed nodes in a task graph, we should use a different type
of event in the database so that they do not look like actual UDFs
executed on the server side.