### PR TITLE
Make description nullable in group update definition

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3107,6 +3107,7 @@ definitions:
       description:
         description: A human readable description of the content of the group
         type: string
+        x-nullable: true
       name:
         description: The name of the group. If must be unique within the group.
         type: string


### PR DESCRIPTION
Clients ignore description when it's an empty string, which means that group description cannot be deleted once set.