### PR TITLE
Update possible array activity event_types

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3964,7 +3964,7 @@ paths:
       - name: event_types
         in: query
         type: string
-        description: Event values can be one or more of the following read, write, create, delete, register, deregister, comma separated
+        description: Event values can be one or more of the following estimated_result_sizes, non_empty_domain, read_schema, query_read, array_metadata_get, query_write, array_metadata_update, create, register, udf, max_buffer_sizes, info, update, deregister, run, delete
       - name: task_id
         in: query
         type: string

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3964,7 +3964,7 @@ paths:
       - name: event_types
         in: query
         type: string
-        description: Event values can be one or more of the following estimated_result_sizes, non_empty_domain, read_schema, query_read, array_metadata_get, query_write, array_metadata_update, create, register, udf, max_buffer_sizes, info, update, deregister, run, delete
+        description: Refer to ActivityEventType for possible values
       - name: task_id
         in: query
         type: string

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1045,7 +1045,7 @@ paths:
         type: array
         items:
           type: string
-        description: Event values can be one or more of the following read, write, create, delete, register, deregister, comma separated
+        description: Event values can be one or more of the following estimated_result_sizes, non_empty_domain, read_schema, query_read, array_metadata_get, query_write, array_metadata_update, create, register, udf, max_buffer_sizes, info, update, deregister, run, delete
       - name: task_id
         in: query
         type: string

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1045,7 +1045,7 @@ paths:
         type: array
         items:
           type: string
-        description: Event values can be one or more of the following estimated_result_sizes, non_empty_domain, read_schema, query_read, array_metadata_get, query_write, array_metadata_update, create, register, udf, max_buffer_sizes, info, update, deregister, run, delete
+        description: Refer to ActivityEventType for possible values
       - name: task_id
         in: query
         type: string


### PR DESCRIPTION
After setting `event_type` filter to `write` i noticed the values are wrong described in the api-spec.