### PR TITLE
Add per–asset type default locations.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1361,11 +1361,17 @@ definitions:
         readOnly: true
         x-omitempty: false
       default_s3_path:
-        description: default S3 path to store newly created notebooks
+        description: >
+          The default location to store newly-created notebooks and other assets
+          like UDFs. The name `default_s3_path` is a legacy holdover; it may
+          refer to any supported storage location.
         type: string
       default_s3_path_credentials_name:
-        description: Default S3 path credentials name is the credentials name to use along with default_s3_path
-        type: string
+        description: >
+          The name of the credentials used to create and access files in the
+          `default_s3_path`, if needed.
+      asset_locations:
+        $ref: '#/definitions/AssetLocations'
       default_namespace_charged:
         description: Override the default namespace charged for actions when no namespace is specified
         type: string
@@ -1463,16 +1469,63 @@ definitions:
         readOnly: true
         x-omitempty: false
       default_s3_path:
-        description: default S3 path to store newly created notebooks
+        description: >
+          The default location to store newly-created notebooks and other assets
+          like UDFs. The name `default_s3_path` is a legacy holdover; it may
+          refer to any supported storage location.
         type: string
       default_s3_path_credentials_name:
-        description: Default S3 path credentials name is the credentials name to use along with default_s3_path
+        description: >
+          The name of the credentials used to create and access files in the
+          `default_s3_path`, if needed.
         type: string
+      asset_locations:
+        $ref: '#/definitions/AssetLocations'
       stripe_connect:
         description: Denotes that the organization is able to apply pricing to arrays by means of Stripe Connect
         type: boolean
         readOnly: true
         example: false
+
+  AssetLocations:
+    description: >
+      Custom storage locations on a per–asset type basis. If any is unset,
+      a suffix of the owning (user/organization) `default_s3_path` is used.
+    type: object
+    properties:
+      arrays:
+        $ref: '#/definitions/StorageLocation'
+      notebooks:
+        $ref: '#/definitions/StorageLocation'
+      udfs:
+        $ref: '#/definitions/StorageLocation'
+      ml_models:
+        $ref: '#/definitions/StorageLocation'
+      files:
+        $ref: '#/definitions/StorageLocation'
+
+  StorageLocation:
+    description: >
+      The path at which a given asset will be stored, and the credentials used
+      to access that asset.
+    type: object
+    properties:
+      path:
+        description: >
+          The path to store this asset type. If unset, a suffix of the user's
+          `default_s3_path` is used. When updating, explicitly set to `""`,
+          the empty string, to clear this path; leaving it `null` (or absent)
+          will leave the path unchanged.
+        x-nullable: true
+        type: string
+      credentials_name:
+        description: >
+          The name of the credentials used to acess this storage path. If unset,
+          the `default_s3_path_credentials_name` is used. When updating,
+          explicitly set to `""`, the empty string, to clear this name;
+          leaving it `null` (or absent) will leave the name unchanged.
+        x-nullable: true
+        type: string
 
   ArraySharing:
     description: details for sharing a given array


### PR DESCRIPTION
This will allow users to specify the location(s) where they wish to store each asset type, rather than putting every single asset in sub-directories of the user’s one default storage path.