### PR TITLE
Update Vacuum and Consolidation routes

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -912,13 +912,19 @@ definitions:
           $ref: "#/definitions/ArrayMetadataEntry"
 
   TileDBConfig:
+    description: TileDB config used for interaction with the embedded library
     type: object
-    description: user's TileDB config
     properties:
-      configs:
-        type: object
-        additionalProperties:
-          type: string
+      entries:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string 
+            value:
+              type: string
+
 
   ArrayActivityLog:
     description: Actvity of an Array
@@ -3891,6 +3897,24 @@ definitions:
         type: boolean
         x-omitempty: true
 
+  ArrayConsolidationRequest:
+    description: Request to consolidate an array
+    type: object
+    properties:
+      config:
+        type: object
+        description: config to use to retrieve the contents
+        $ref: "#/definitions/TileDBConfig"
+
+  ArrayVacuumRequest:
+    description: Request to consolidate an array
+    type: object
+    properties:
+      config:
+        type: object
+        description: config to use to retrieve the contents
+        $ref: "#/definitions/TileDBConfig"
+
 paths:
   /.stats:
     get:
@@ -4372,11 +4396,11 @@ paths:
         - array
       operationId: consolidateArray
       parameters:
-        - name: tiledb_config
+        - name: consolidate_request
           in: body
-          description: tiledb configuration
+          description: Consolidate Request
           schema:
-            $ref: "#/definitions/TileDBConfig"
+            $ref: "#/definitions/ArrayConsolidationRequest"
           required: true
       responses:
         204:
@@ -4406,11 +4430,11 @@ paths:
         - array
       operationId: vacuumArray
       parameters:
-        - name: tiledb_config
+        - name: vaccum_request
           in: body
-          description: tiledb configuration
+          description: Vaccum Request
           schema:
-            $ref: "#/definitions/TileDBConfig"
+            $ref: "#/definitions/ArrayVacuumRequest"
           required: true
       responses:
         204:


### PR DESCRIPTION
These routes were never released into full production and plumbed by clients. We are now enabling them in core and I've updated the models and specs for the actual client implementations.