### PR TITLE
Add group type

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3014,6 +3014,20 @@ definitions:
       # Edit: update attributes, add and remove assets
       - edit
 
+  GroupType:
+    description: Group type is a hint for the groups contents and TileDB Cloud may use a specialized viewer for each type
+    type: string
+    enum:
+      - vcf
+      - soma
+      - bioimg
+
+  GroupTypeMetadataKey:
+    description: A group type is stored in the group metadata using this key
+    type: string
+    enum:
+      - dataset_type
+
   GroupInfo:
     description: metadata of a group
     type: object
@@ -3070,6 +3084,10 @@ definitions:
         x-omitempty: true
         items:
           $ref: "#/definitions/GroupActions"
+      group_type:
+        description: the type of the group
+        $ref: "#/definitions/GroupType"
+        x-omitempty: true
       logo:
         description: logo (base64 encoded) for the gruop. Optional
         type: string
@@ -8242,6 +8260,11 @@ paths:
           description: pagination limit
           type: integer
           required: false
+        - name: type
+          in: query
+          description: filter by a specific group type
+          required: false
+          type: string
         - name: search
           in: query
           description: search string that will look at name, namespace or description fields
@@ -8333,6 +8356,11 @@ paths:
           description: pagination limit
           type: integer
           required: false
+        - name: type
+          in: query
+          description: filter by a specific group type
+          required: false
+          type: string
         - name: search
           in: query
           description: search string that will look at name, namespace or description fields
@@ -8432,6 +8460,11 @@ paths:
           description: pagination limit
           type: integer
           required: false
+        - name: type
+          in: query
+          description: filter by a specific group type
+          required: false
+          type: string
         - name: search
           in: query
           description: search string that will look at name, namespace or description fields

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3170,6 +3170,12 @@ definitions:
         x-omitempty: false
         items:
           type: string
+      group_types:
+        description: list of all available group types to display
+        type: array
+        x-omitempty: false
+        items:
+          $ref: "#/definitions/GroupType"
 
   GroupContentsFilterData:
     description: Object with data to fill contents filter

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -8266,7 +8266,7 @@ paths:
           description: pagination limit
           type: integer
           required: false
-        - name: type
+        - name: group_type
           in: query
           description: filter by a specific group type
           required: false
@@ -8362,7 +8362,7 @@ paths:
           description: pagination limit
           type: integer
           required: false
-        - name: type
+        - name: group_type
           in: query
           description: filter by a specific group type
           required: false
@@ -8466,7 +8466,7 @@ paths:
           description: pagination limit
           type: integer
           required: false
-        - name: type
+        - name: group_type
           in: query
           description: filter by a specific group type
           required: false


### PR DESCRIPTION
Group type is a group attribute that gives a hint about the contents:soma, vcf, bioimg. TileDB cloud UI may use a specialized viewer for the contents of groups of a particular type

https://app.shortcut.com/tiledb-inc/story/26395/modify-groups-for-verticals-implementation#activity-26989