### PR TITLE
Array type should be nillable

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1800,9 +1800,10 @@ definitions:
         description: the name of the access credentials to use. if unset, the default credentials will be used
         type: string
       type:
-        description: Array type (dense, key-value, sparse)
-        type: string
+        description: Array type (dense, key-value, sparse). Calculation of array type runs after array has been registered. So, it is not available immediately.
         example: sparse
+        x-nullable: true
+        $ref: "#/definitions/ArrayType"
       share_count:
         description: number of unique namespaces this array is shared with
         type: number


### PR DESCRIPTION
Array type should be nillable. For more info check 
https://app.shortcut.com/tiledb-inc/story/27241/array-type-is-not-returned-after-array-registration