### PR TITLE
Allow udfs to have env variables set for credentials

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2127,6 +2127,9 @@ definitions:
         type: string
         description: Docker image name to use for UDF
         x-omitempty: true
+      access_credentials_name:
+        description: The name of the access credentials to use. if unset, no credentials will be configured in the environment.
+        type: string
       resource_class:
         type: string
         description: >
@@ -2228,6 +2231,9 @@ definitions:
         type: string
         description: Docker image name to use for UDF
         x-omitempty: true
+      access_credentials_name:
+        description: The name of the access credentials to use. if unset, no credentials will be configured in the environment.
+        type: string
       resource_class:
         type: string
         description: >
@@ -3956,6 +3962,10 @@ definitions:
       image_name:
         description: >
           The name of the image to use for the execution environment.
+        type: string
+      access_credentials_name:
+        description: >
+          The name of the access credentials to use. if unset, no credentials will be configured in the environment.
         type: string
       namespace:
         description: >

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1441,6 +1441,10 @@ definitions:
         type: string
         format: date-time
         readOnly: true
+      allowed_in_tasks:
+        description: "Is this credential allowed to be used in tasks"
+        type: boolean
+        x-nullable: true
       credential:
         description: "The credential information itself. Exactly one sub-field may be set. The names match those in the CloudProvider enum."
         type: object


### PR DESCRIPTION
This adds allowed_in_tasks parameter for `AccessCredentials` and adds access_credentials_name to `Generic`/`MultiArrayUDF` and `TGUDFEnvironment`.