### PR TITLE
V2: Extend group member asset type

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1756,6 +1756,12 @@ definitions:
       - ml_model
       # Files
       - file
+      # Biomedical Imaging
+      - bioimg
+      # SOMA
+      - soma
+      # VCF
+      - vcf
 
   GroupMember:
     description: A groups member, array or another groups, to add or remove from an existing group.


### PR DESCRIPTION
This change was made in v1 but the enum exists in v2 as well.