### PR TITLE
Add v2.deleteGroup

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -2355,6 +2355,38 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /groups/{group_namespace}/{group_name}/delete:
+    parameters:
+      - name: group_namespace
+        type: string
+        in: path
+        required: true
+        description: The namespace of the group
+      - name: group_name
+        type: string
+        in: path
+        required: true
+        description: The unique name or id of the group
+      - name: recursive
+        in: query
+        description: If true, it descends in the group and deletes every subgroup and subarray
+        type: string
+        required: false
+    delete:
+      description: Deregisters and physically deletes a group
+      operationId: deleteGroup
+      tags:
+        - groups
+      responses:
+        204:
+          description: group deleted successfully
+        502:
+          description: Bad Gateway
+        default:
+          description: error response
+          schema:
+            $ref: "#/definitions/Error"
+
   /files/{namespace}/{array}/upload:
     parameters:
       - type: string


### PR DESCRIPTION
The endpoint is DELETE /v2/groups/{namespace}/{name}/delete?recursive=true

This will used to physically delete groups and members. With recursive, it descends recursively in the group and deletes all groups and array submembers. Without it, it just deletes the group.

This endpoint will be used by TileDB core, see https://github.com/TileDB-Inc/TileDB/pull/4124 and by REST server see https://github.com/TileDB-Inc/TileDB-Cloud-REST/pull/3667
