### PR TITLE
Update invitation definition to support registered namespaces

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2992,6 +2992,17 @@ definitions:
         type: string
         format: date-time
         x-omitempty: false
+      namespace_invited:
+        description: The namespace invited (user or organization, if it exists in the DB)
+        type: object
+        x-omitempty: true
+        properties:
+          id:
+            description: The namespace uuid
+            type: string
+          namespace:
+            description: The namespace name (username or organization name)
+            type: string
 
   InvitationData:
     description: Object including invitations and metadata


### PR DESCRIPTION
Invitations can be now sent to registered namespaces in addition to emails.
Added an extra optional field in the invitation object for the namespace details.