### PR TITLE
Update responses of the create invitation requests to support partial success

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2847,6 +2847,18 @@ definitions:
         items:
           type: string
 
+  InvitationFailedRecipients:
+    description: Encapsulates information regarding the failed invitation recipients
+    type: object
+    required:
+      - failed_recipients
+    properties:
+      failed_recipients:
+        type: array
+        x-omitempty: true
+        items:
+          type: string
+
   InvitationGroupShareEmail:
     description: Encapsulates information regarding inviting people using email to share group, same permissions for all invitees
     type: object
@@ -7695,10 +7707,14 @@ paths:
       responses:
         204:
           description: Email sent successfully to user for email confirmation link
-        404:
-          description: Could not reach one or more recipients
+        207:
+          description: Only a portion of the invitations succeeded, some failed
           schema:
-            $ref: "#/definitions/InvitationArrayShareEmail"
+            $ref: "#/definitions/InvitationFailedRecipients"
+        500:
+          description: Could not reach any recipients
+          schema:
+            $ref: "#/definitions/InvitationFailedRecipients"
         502:
           description: Bad Gateway
         default:
@@ -7733,10 +7749,14 @@ paths:
       responses:
         204:
           description: Email sent successfully to user with an email confirmation link
-        404:
-          description: Could not reach one or more recipients
+        207:
+          description: Only a portion of the invitations succeeded, some failed
           schema:
-            $ref: "#/definitions/InvitationGroupShareEmail"
+            $ref: "#/definitions/InvitationFailedRecipients"
+        500:
+          description: Could not reach any recipients
+          schema:
+            $ref: "#/definitions/InvitationFailedRecipients"
         502:
           description: Bad Gateway
         default:
@@ -7766,10 +7786,14 @@ paths:
       responses:
         204:
           description: Email sent successfully to user for email confirmation link
-        404:
-          description: Could not reach one or more recipients
+        207:
+          description: Only a portion of the invitations succeeded, some failed
           schema:
-            $ref: "#/definitions/InvitationOrganizationJoinEmail"
+            $ref: "#/definitions/InvitationFailedRecipients"
+        500:
+          description: Could not reach any recipients
+          schema:
+            $ref: "#/definitions/InvitationFailedRecipients"
         502:
           description: Bad Gateway
         default:


### PR DESCRIPTION
Sending multiple invitations at once means that some of them may succeed while others may not.
This PR introduces a new response with the failed recipients along with an extra "207" response if the request **partially** succeeds.
Clients will be able to handle each case accordingly.