### PR TITLE
invitation: update namespace invited definition

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2994,15 +2994,8 @@ definitions:
         x-omitempty: false
       namespace_invited:
         description: The namespace invited (user or organization, if it exists in the DB)
-        type: object
+        type: string
         x-omitempty: true
-        properties:
-          id:
-            description: The namespace uuid
-            type: string
-          namespace:
-            description: The namespace name (username or organization name)
-            type: string
 
   InvitationData:
     description: Object including invitations and metadata


### PR DESCRIPTION
The namespace_invited property is not supported at the moment by the REST server.
I updated the definition to be a single string since this value is optional and informational only.