### PR TITLE
Remove last_accessed from arrays browser ordering filter

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -7829,7 +7829,7 @@ paths:
         type: string
       - name: orderby
         in: query
-        description: sort by which field valid values include last_accessed, size, name
+        description: sort by which field valid values include size, name
         required: false
         type: string
       - name: permissions
@@ -7975,7 +7975,7 @@ paths:
         type: string
       - name: orderby
         in: query
-        description: sort by which field valid values include last_accessed, size, name
+        description: sort by which field valid values include size, name
         required: false
         type: string
       - name: permissions
@@ -8105,7 +8105,7 @@ paths:
         type: string
       - name: orderby
         in: query
-        description: sort by which field valid values include last_accessed, size, name
+        description: sort by which field valid values include size, name
         required: false
         type: string
       - name: permissions


### PR DESCRIPTION
https://app.shortcut.com/tiledb-inc/story/28302/ordering-by-last-accessed-no-longer-supported-in-array-browser