### PR TITLE
Fill missing TileDB datatypes

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -89,6 +89,54 @@ definitions:
       - STRING_UCS4
       # This can be any datatype. Must store (type tag, value) pairs.
       - ANY
+      # Datetime with year resolution
+      - DATETIME_YEAR
+      # Datetime with month resolution
+      - DATETIME_MONTH
+      # Datetime with week resolution
+      - DATETIME_WEEK
+      # Datetime with day resolution
+      - DATETIME_DAY
+      # Datetime with hour resolution
+      - DATETIME_HR
+      # Datetime with minute resolution
+      - DATETIME_MIN
+      # Datetime with second resolution
+      - DATETIME_SEC
+      # Datetime with millisecond resolution
+      - DATETIME_MS
+      # Datetime with microsecond resolution
+      - DATETIME_US
+      # Datetime with nanosecond resolution
+      - DATETIME_NS
+      # Datetime with picosecond resolution
+      - DATETIME_PS
+      # Datetime with femtosecond resolution
+      - DATETIME_FS
+      # Datetime with attosecond resolution
+      - DATETIME_AS
+      # Time with hour resolution
+      - TIME_HR
+      # Time with minute resolution
+      - TIME_MIN
+      # Time with second resolution
+      - TIME_SEC
+      # Time with millisecond resolution
+      - TIME_MS
+      # Time with microsecond resolution
+      - TIME_US
+      # Time with nanosecond resolution
+      - TIME_NS
+      # Time with picosecond resolution
+      - TIME_PS
+      # Time with femtosecond resolution
+      - TIME_FS
+      # Time with attosecond resolution
+      - TIME_AS
+      # 8-bit unsigned integer
+      - BLOB
+      # Boolean
+      - BOOL
 
   ActivityEventType:
     description: Type of activity logged

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -113,34 +113,56 @@ definitions:
       - STRING_UCS2
       # UCS4 string
       - STRING_UCS4
-      # Years
-      - DATETIME_YEAR
-      # Months
-      - DATETIME_MONTH
-      # Weeks
-      - DATETIME_WEEK
-      # Days
-      - DATETIME_DAY
-      # Hours
-      - DATETIME_HR
-      # Minutes
-      - DATETIME_MIN
-      # Seconds
-      - DATETIME_SEC
-      # Milliseconds
-      - DATETIME_MS
-      # Microseconds
-      - DATETIME_US
-      # Nanoseconds
-      - DATETIME_NS
-      # Picoseconds
-      - DATETIME_PS
-      # Femtoseconds
-      - DATETIME_FS
-      # Attoseconds
-      - DATETIME_AS
       # This can be any datatype. Must store (type tag, value) pairs.
       - ANY
+      # Datetime with year resolution
+      - DATETIME_YEAR
+      # Datetime with month resolution
+      - DATETIME_MONTH
+      # Datetime with week resolution
+      - DATETIME_WEEK
+      # Datetime with day resolution
+      - DATETIME_DAY
+      # Datetime with hour resolution
+      - DATETIME_HR
+      # Datetime with minute resolution
+      - DATETIME_MIN
+      # Datetime with second resolution
+      - DATETIME_SEC
+      # Datetime with millisecond resolution
+      - DATETIME_MS
+      # Datetime with microsecond resolution
+      - DATETIME_US
+      # Datetime with nanosecond resolution
+      - DATETIME_NS
+      # Datetime with picosecond resolution
+      - DATETIME_PS
+      # Datetime with femtosecond resolution
+      - DATETIME_FS
+      # Datetime with attosecond resolution
+      - DATETIME_AS
+      # Time with hour resolution
+      - TIME_HR
+      # Time with minute resolution
+      - TIME_MIN
+      # Time with second resolution
+      - TIME_SEC
+      # Time with millisecond resolution
+      - TIME_MS
+      # Time with microsecond resolution
+      - TIME_US
+      # Time with nanosecond resolution
+      - TIME_NS
+      # Time with picosecond resolution
+      - TIME_PS
+      # Time with femtosecond resolution
+      - TIME_FS
+      # Time with attosecond resolution
+      - TIME_AS
+      # 8-bit unsigned integer
+      - BLOB
+      # Boolean
+      - BOOL
 
   Layout:
     description: Layout of array


### PR DESCRIPTION
from https://github.com/TileDB-Inc/TileDB/blob/dev/tiledb/api/c_api/datatype/datatype_api_enum.h