### PR TITLE
Add read_write_delete user role

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -298,6 +298,8 @@ definitions:
       - admin
       # Read and write User
       - read_write
+      # Read and write and delete asset user
+      - read_write_delete
       # Read Only User
       - read_only
 


### PR DESCRIPTION
Adds a new organization role user that has delete permissions on assets. Note: this does not affect the users role with regards to deletion of the organization, only within the asset itself