### PR TITLE
feat: [sc-35929] Filter by user on activity

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3755,6 +3755,8 @@ definitions:
       - idle
         # The graph is not yet completed, but nothing is actively running.
         # This should not be reported by the client.
+      - unfinished
+        # The task graph is unfinished
       - abandoned
         # The graph has been idle for an extended period of time, likely due to
         # the client crashing or aborting without notifying the server.

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -9662,6 +9662,11 @@ paths:
         description: Include logs from only this user.
         type: string
         required: false
+      - name: status
+        in: query
+        description: Filter to only return these statuses
+        type: string
+        required: false
       - name: search
         in: query
         description: search string that will look at name.


### PR DESCRIPTION
Status param is already [supported in REST](https://github.com/TileDB-Inc/TileDB-Cloud-REST/blob/a8ada62318c5592feba7c71286cc1787ac64d007/internal/taskgraphs/logs/api/logs.go#L264) but missing from api-spec.
Furthermore, after checking the DB for the taskgraph log statuses i noticed that we are missing `UNFINISHED`.

```sql
select DISTINCT status  from ...;
```
`FAILED
SUCCEEDED
CANCELLED
UNFINISHED`

Story details: https://app.shortcut.com/tiledb-inc/story/35929