### PR TITLE
TaskGraph Stop route return 204 not 202

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2,7 +2,7 @@ swagger: "2.0"
 info:
   description: TileDB Storage Platform REST API
   title: TileDB Storage Platform API
-  version: 2.2.19
+  version: 2.17.51
 
 produces:
   - application/json
@@ -9920,10 +9920,8 @@ paths:
       tags:
         - task_graph_logs
       responses:
-        202:
-          description: Information about the task graph execution.
-          schema:
-            $ref: "#/definitions/TaskGraphLog"
+        204:
+          description: Graph stopped successfully
         502:
           description: Bad Gateway
         default:


### PR DESCRIPTION
TaskGraph Stop route return 204 not 202. This was causing clients to incorrectly handle the 204 as a default case. I also bumped the version of the spec file.