### PR TITLE
Add key_id to AWSRole.role_arn.

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1617,7 +1617,7 @@ definitions:
         description: "The role arn used to access"
         x-go-name: "RoleARN"
         type: string
-        x-go-custom-tag: 'validate:"required" tdbrest:"limit_20"'
+        x-go-custom-tag: 'validate:"required" tdbrest:"key_id,limit_20"'
         example: arn:partition:service:region:account-id:resource-type:resource-id
       external_id:
         description: "The role external id used to access"


### PR DESCRIPTION
role_arn identifies what the key belongs to and should be labelled.