### PR TITLE
Add "perdomain" and "SCIM" SSO enum values.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2241,6 +2241,10 @@ definitions:
       - stripe
       # Okta
       - okta
+      # perdomain
+      - perdomain
+      # SCIM
+      - scim
 
   PublicShareFilter:
     description: Query parameter to get array metadatas


### PR DESCRIPTION
- "perdomain" is an enum value we already use in the server, representing users who have logged in with our per-domain SSO support.
- "scim" isn't quite like other SSO values, in that it represents that the user was *created* by SCIM. However, SCIM itself doesn't provide authentication; it's purely a provisioning protocol.