### PR TITLE
Change geospatial group types to be represented by arrays

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3332,12 +3332,6 @@ definitions:
       - soma
       # Biomedical Imaing
       - bioimg
-      # Point Cloud
-      - pointcloud
-      # Raster
-      - raster
-      # Geometry
-      - geometry
       # Vector search
       - vector_search
 


### PR DESCRIPTION
pointcloud, raster, and geometry asset types are backed by arrays, not groups.