### PR TITLE
Remove invalid taskgraph log status

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3827,8 +3827,6 @@ definitions:
       - idle
         # The graph is not yet completed, but nothing is actively running.
         # This should not be reported by the client.
-      - unfinished
-        # The task graph is unfinished
       - abandoned
         # The graph has been idle for an extended period of time, likely due to
         # the client crashing or aborting without notifying the server.


### PR DESCRIPTION
This status is not supported by REST server. It is never returned as a status of a taskgraph log and does not apply as a filter in the listing route.