### PR TITLE
Add length limit to `TaskGraphNodeMetadata`.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3954,6 +3954,7 @@ definitions:
         description: The client-generated UUID of the given graph node.
       name:
         type: string
+        maxLength: 255
         description: >
           The client-generated name of the node.
           This is not guaranteed to be unique.


### PR DESCRIPTION
This is a follow-up to https://github.com/TileDB-Inc/TileDB-Cloud-API-Spec/pull/458.