### PR TITLE
Add internal to array task types

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1032,6 +1032,7 @@ definitions:
       - GENERIC_UDF
       - BATCH_UDF
       - CLIENT_COMPUTATION
+      - INTERNAL
 
   ArrayTaskStatus:
     description: Status of array task


### PR DESCRIPTION
Adds a new array task type definition for tasks that are internal to the other tasks processes such as estimate result sizes.