### PR TITLE
Add Fragments to ArrayConsolidationRequest.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -4722,6 +4722,12 @@ definitions:
         type: object
         description: config to use to retrieve the contents
         $ref: "#/definitions/TileDBConfig"
+      fragments:
+        description: list of fragments in the array to consolidate
+        type: array
+        x-omitempty: true
+        items:
+          type: string
 
   ArrayVacuumRequest:
     description: Request to consolidate an array


### PR DESCRIPTION
This adds Fragments to ArrayConsolidationRequest model generated by swagger. An example of the sources after generating with this change can be found at https://github.com/TileDB-Inc/TileDB-Cloud-REST/commit/30ca1d61eafbddd2a8db76b5b7d50cdf034fe7d5

This was added to support fragment list consolidation in REST [SC-48773](https://app.shortcut.com/tiledb-inc/story/48773/cloud-rest-support-for-fragment-list-consolidation-and-vacuuming)