### PR TITLE
Added request_id in v2 Error definition

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1472,6 +1472,8 @@ definitions:
         format: int64
       message:
         type: string
+      request_id:
+        type: string
 
   AccessCredentialType:
     description: "The types of an access credential"


### PR DESCRIPTION
REST server returns a `request_id` in the error payload, which is defined in v1 but not in v2.