### PR TITLE
Added status_message to the TaskGraphLog definition

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3946,6 +3946,10 @@ definitions:
         description: The UUID of the task graph.
       region:
         $ref: "#/definitions/CloudRegion"
+      status_message:
+        type: string
+        description: A system message providing more info about a potential status change
+        x-nullable: true
 
   TaskGraphNodeMetadata:
     description: Metadata about an individual node in a task graph.


### PR DESCRIPTION
REST server may provide a message related to a potential status change of the task graph log.