### PR TITLE
Update how cloud provider and region are set.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1192,8 +1192,14 @@ definitions:
         x-omitempty: true
         description: >
           If set, the client-defined ID of the node within this task's graph.
-      region:
-        $ref: "#/definitions/CloudRegion"
+      cloud_provider:
+        type: string
+        x-omitempty: true
+        description: The name of the cloud provider where this task executed.
+      cloud_region:
+        type: string
+        x-omitempty: true
+        description: The region of the cloud provider where this task executed.
 
   PaginationMetadata:
     properties:
@@ -3944,8 +3950,14 @@ definitions:
       task_graph_id:
         type: string
         description: The UUID of the task graph.
-      region:
-        $ref: "#/definitions/CloudRegion"
+      cloud_provider:
+        type: string
+        x-omitempty: true
+        description: The name of the cloud provider where this task graph executed.
+      cloud_region:
+        type: string
+        x-omitempty: true
+        description: The region of the cloud provider where this task graph executed.
 
   TaskGraphNodeMetadata:
     description: Metadata about an individual node in a task graph.
@@ -4856,19 +4868,6 @@ definitions:
       - OnError
       # Retry task transient errors
       - OnTransientError
-
-  CloudRegion:
-    description: Represents the region of a particular cloud provider
-    type: object
-    properties:
-      provider:
-        description: The cloud provider's name, e.g. "AWS"
-        type: string
-        enum:
-          - AWS
-      region:
-        description: The cloud provider's region, e.g. "us-east-1"
-        type: string
 
 paths:
   /.stats:


### PR DESCRIPTION
Remove the `CloudRegion` object that previously encapsulated the cloud provider and region.