### PR TITLE
Add embedded flag for ArraySchema.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -675,6 +675,7 @@ definitions:
         package: "github.com/TileDB-Inc/TileDB-Go"
         alias: "tiledb"
       type: "ArraySchema"
+      embedded: true
 
   AttributeBufferHeader:
     description: Represents an attribute buffer header information


### PR DESCRIPTION
This uses the `embedded` flag for ArraySchema to wrap the external TileDB-Go ArraySchema type within generated swagger sources in TileDB-Cloud-REST. The result fixes errors in sources generated by swagger that expect the `Validatable` interface to be implemented. 

With this change there's no need to modify swagger sources manually after regenerating. Examples of generated sources [before](https://github.com/TileDB-Inc/TileDB-Cloud-REST/pull/4686/commits/7fe52267a1c40a3b4d463d88ae732c7d0a8931d1) and [after
](https://github.com/TileDB-Inc/TileDB-Cloud-REST/pull/4686/commits/2a985069d308ffd044eb64652965f4dbd8e0f23f)

https://github.com/fredbi/go-swagger/blob/master/docs/reference/models/schemas.md#embedding-external-types