### PR TITLE
Match LoadArraySchemaResponse property names with core capnp spec.

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -4816,9 +4816,9 @@ definitions:
     description: Contains the latest schema and all schemas for the opened array
     type: object
     properties:
-      latest_array_schema:
+      schema:
         $ref: "#/definitions/ArraySchema"
-      all_array_schemas:
+      arraySchemasAll:
         description: map of all array schemas
         type: object
         additionalProperties:


### PR DESCRIPTION
This updates the property names for LoadArraySchemaResponse to match those in Core. This came up after debugging issues unmarshaling LoadArraySchemaResponse in REST unit tests. IIUC the property names for the OpenAPI specification must match the field names in core's capnproto specification.

Alternatively I can open a PR in core to use snake case across the board, or open to other suggestions if there is another way to make this work without identical property names.