### PR TITLE
chore: [sc-52648] Remove http status 202 from /v1/notebooks/server/{namespace}/status

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -7612,8 +7612,6 @@ paths:
           description: status of running notebook
           schema:
             $ref: "#/definitions/NotebookStatus"
-        202:
-          description: Notebook server is pending
         402:
           description: Payment required
           schema:


### PR DESCRIPTION
Story details: https://app.shortcut.com/tiledb-inc/story/52648