### PR TITLE
Added metadata field to the ArrayInfo and GroupInfo definitions

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -980,6 +980,7 @@ definitions:
         description: The metadata type
         type: string
         x-omitempty: false
+        example: array_metadata
 
   TileDBConfig:
     description: TileDB config used for interaction with the embedded library

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -4965,7 +4965,7 @@ paths:
         required: true
       - name: with_metadata
         in: query
-        description: include the metadata of the groups
+        description: include the metadata of the arrays
         type: boolean
         required: false
     get:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -964,6 +964,23 @@ definitions:
         items:
           $ref: "#/definitions/ArrayMetadataEntry"
 
+  MetadataStringifiedEntry:
+    type: object
+    description: key/value pair representing an asset metadata map entry
+    properties:
+      key:
+        description: The metadata key
+        type: string
+        x-omitempty: false
+      value:
+        description: The metadata value
+        type: string
+        x-omitempty: false
+      type:
+        description: The metadata type
+        type: string
+        x-omitempty: false
+
   TileDBConfig:
     description: TileDB config used for interaction with the embedded library
     type: object
@@ -2102,6 +2119,14 @@ definitions:
         description: Datetime array was registered with tiledb
         type: string
         format: date-time
+      metadata:
+        description: |
+          Contains the metadata of the array.
+          **Note:** This property is included in the response only if the `with_metadata` query parameter is set to `true`.
+        type: array
+        x-omitempty: true
+        items:
+          $ref: "#/definitions/MetadataStringifiedEntry"
 
   ArrayInfoUpdate:
     description: metadata of an array
@@ -3452,6 +3477,14 @@ definitions:
         description: Datetime the group was registered with tiledb
         type: string
         format: date-time
+      metadata:
+        description: |
+          Contains metadata of the group.
+          **Note:** This property is included in the response only if the `with_metadata` query parameter is set to `true`.
+        type: array
+        x-omitempty: true
+        items:
+          $ref: "#/definitions/MetadataStringifiedEntry"
 
   GroupEntry:
     description: Object describing a single member of a group, which can be an array or a group
@@ -4930,6 +4963,11 @@ paths:
         description: namespace array is in (an organization name or user's username)
         type: string
         required: true
+      - name: with_metadata
+        in: query
+        description: include the metadata of the groups
+        type: boolean
+        required: false
     get:
       description: get metadata on all arrays in a namespace
       tags:
@@ -8311,6 +8349,11 @@ paths:
         collectionFormat: multi
         items:
           type: string
+      - name: with_metadata
+        in: query
+        description: include the metadata of the array
+        type: boolean
+        required: false
     get:
       tags:
         - array
@@ -8449,6 +8492,11 @@ paths:
         collectionFormat: multi
         items:
           type: string
+      - name: with_metadata
+        in: query
+        description: include the metadata of the array
+        type: boolean
+        required: false
     get:
       tags:
         - array
@@ -8579,6 +8627,11 @@ paths:
         collectionFormat: multi
         items:
           type: string
+      - name: with_metadata
+        in: query
+        description: include the metadata of the array
+        type: boolean
+        required: false
     get:
       tags:
         - array
@@ -9275,6 +9328,11 @@ paths:
           description: search only the children of the groups with this uuid
           type: string
           required: false
+        - name: with_metadata
+          in: query
+          description: include the metadata of the groups
+          type: boolean
+          required: false
       responses:
         200:
           description: the group contents
@@ -9385,6 +9443,11 @@ paths:
           collectionFormat: multi
           items:
             type: string
+        - name: with_metadata
+          in: query
+          description: include the metadata of the groups
+          type: boolean
+          required: false
       responses:
         200:
           description: the group contents
@@ -9480,6 +9543,11 @@ paths:
           in: query
           description: search only the children of the groups with this uuid
           type: string
+          required: false
+        - name: with_metadata
+          in: query
+          description: include the metadata of the groups
+          type: boolean
           required: false
       responses:
         200:


### PR DESCRIPTION
Clients can now pass a new query parameter `with_metadata` (boolean) to extend the ArrayInfo or GroupInfo objects to also include their metadata in the corresponding end points.