### PR TITLE
Add expires parameter to session request

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -7046,6 +7046,12 @@ paths:
         description: flag to create a token with expiration of 30 days, default is false
         type: string
         required: false
+      - name: expires
+        in: query
+        description: Expiration date for token, if empty token defaults to 30 minutes
+        type: string
+        format: date-time
+        required: false
     get:
       tags:
         - user


### PR DESCRIPTION
This allows for a client that is requesting a temporary session to set a custom expiration date. Any limitations on the duration will be enforced serverside when parsing the request.