### PR TITLE
add boolean is_deleted to v1 group info

### DIFF
--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3496,6 +3496,9 @@ definitions:
         description: The username of the group's creator, if known.
         type: string
         x-omitempty: true
+      is_deleted:
+        description: Indicates whether the group is deleted
+        type: boolean
       metadata:
         description: |
           Contains metadata of the group.


### PR DESCRIPTION
Add boolean indication in group info to know if a group has been deleted.
The change is in v1 GroupInfo that is used by the UI