### PR TITLE
Add support for AWS KMS key ID with credentials

### DIFF
--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1618,12 +1618,17 @@ definitions:
         description: "The access key's secret. Never returned in responses."
         type: string
         x-go-custom-tag: 'tdbrest:"secret" validate:"required"'
-
       endpoint:
         description: "The endpoint used for this credential"
         x-nullable: true
         type: string
         example: "https://example.us-west-2.amazonaws.com"
+      kms_id:
+        x-nullable: true
+        description: "The kms arn to use with this credential"
+        type: string
+        example: "arn:aws:kms:us-east-1:1234:key/mykey"
+
 
   AzureCredential:
     description: "Credential information to access Microsoft Azure. Each supported property is the snake_case version of its name in an Azure Storage connection string."
@@ -1678,6 +1683,11 @@ definitions:
         description: "The endpoint used for this role"
         type: string
         example: "https://example.us-west-2.amazonaws.com"
+      kms_id:
+        x-nullable: true
+        description: "The kms arn to use with this role"
+        type: string
+        example: "arn:aws:kms:us-east-1:1234:key/mykey"
 
   AzureToken:
     description: "Token information to access Azure services"

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -1623,9 +1623,9 @@ definitions:
         x-nullable: true
         type: string
         example: "https://example.us-west-2.amazonaws.com"
-      kms_id:
+      sse_kms_key_id:
         x-nullable: true
-        description: "The kms arn to use with this credential"
+        description: "The key ID, key ARN, or key alias of the AWS KMS key to use with this credential"
         type: string
         example: "arn:aws:kms:us-east-1:1234:key/mykey"
 
@@ -1683,9 +1683,9 @@ definitions:
         description: "The endpoint used for this role"
         type: string
         example: "https://example.us-west-2.amazonaws.com"
-      kms_id:
+      sse_kms_key_id:
         x-nullable: true
-        description: "The kms arn to use with this role"
+        description: "The key ID, key ARN, or key alias of the AWS KMS key to use with this credential"
         type: string
         example: "arn:aws:kms:us-east-1:1234:key/mykey"
 


### PR DESCRIPTION
This adds a new parameter to AWSCredential/AWSRole to allow a user to associate a KMS key arn with the credential to be used. This allows the system to support KMS based s3 encryption in a more automated fashion without the user having to pass the key arn for each request manually.